### PR TITLE
feat: allow sequence-controlled part spawning

### DIFF
--- a/Assets/SimuLean.Net/SimElements/InfiniteSource.cs
+++ b/Assets/SimuLean.Net/SimElements/InfiniteSource.cs
@@ -9,29 +9,45 @@
 
         int numberIterms;
 
-        public InfiniteSource(string name, SimClock state) : base(name, state)
+        IList<int> itemSequence;
+
+        int sequenceIndex;
+
+        public InfiniteSource(string name, SimClock state, IList<int> sequence = null) : base(name, state)
         {
+            this.itemSequence = sequence;
+        }
+
+        public void SetSequence(IList<int> sequence)
+        {
+            this.itemSequence = sequence;
+            sequenceIndex = 0;
         }
 
         public override void Start()
         {
             numberIterms = 0;
+            sequenceIndex = 0;
 
             simClock.ScheduleEvent(this, 0.0);
         }
 
         public override bool Unblock()
         {
+            if (lastItem == null)
+            {
+                lastItem = CreateItem();
+                if (lastItem == null)
+                    return false;
+            }
 
             if (this.GetOutput().SendItem(lastItem, this))
             {
-                lastItem = CreateItem();
-                numberIterms++;
+                lastItem = null;
                 return true;
             }
 
-            else
-                return false;
+            return false;
         }
 
         public int GetNumberItems()
@@ -56,24 +72,42 @@
 
         void Eventcs.Execute()
         {
-            int i = 0;
-            do
+            while (true)
             {
-                lastItem = CreateItem();
-                numberIterms++;
+                if (lastItem == null)
+                {
+                    lastItem = CreateItem();
+                    if (lastItem == null)
+                        break;
+                }
+
+                if (!this.GetOutput().SendItem(lastItem, this))
+                    break;
+
+                lastItem = null;
             }
-            while (this.GetOutput().SendItem(lastItem, this));
         }
 
         /// <summary>
-        /// Creates new item.
+        /// Creates new item following the predefined sequence if provided.
         /// </summary>
-        /// <returns>The item created.</returns>
+        /// <returns>The item created or <c>null</c> if sequence is finished.</returns>
         Item CreateItem()
         {
+            if (itemSequence != null && sequenceIndex >= itemSequence.Count)
+                return null;
+
+            int typeId = 1;
+            if (itemSequence != null)
+            {
+                typeId = itemSequence[sequenceIndex];
+                sequenceIndex++;
+            }
+
             Item nItem = new Item(simClock.GetSimulationTime());
-            nItem.SetId("type", 1, 1);
+            nItem.SetId("type", typeId, typeId);
             nItem.vItem = vElement.GenerateItem(nItem.GetId());
+            numberIterms++;
 
             return nItem;
         }

--- a/Assets/UnitySimuLean/UnityInfinitySource.cs
+++ b/Assets/UnitySimuLean/UnityInfinitySource.cs
@@ -17,9 +17,20 @@ namespace UnitySimuLean
 
         public Transform itemPosition;
 
+        public System.Collections.Generic.IList<int> partSequence;
+
+        public void SetSequence(System.Collections.Generic.IList<int> sequence)
+        {
+            partSequence = sequence;
+            if (theSource != null)
+            {
+                theSource.SetSequence(partSequence);
+            }
+        }
+
         override public void InitializeSim()
         {
-            theSource = new InfiniteSource(name, UnitySimClock.Instance.clock);
+            theSource = new InfiniteSource(name, UnitySimClock.Instance.clock, partSequence);
             if (Experimenter.HeadlessActive)
             {
                 theSource.vElement = new NullVElement();
@@ -32,6 +43,10 @@ namespace UnitySimuLean
         }
         override public void StartSim()
         {
+            if (partSequence != null)
+            {
+                theSource.SetSequence(partSequence);
+            }
             theSource.Start();
         }
 

--- a/Assets/UnitySimuLean/UnitySequenceRunner.cs
+++ b/Assets/UnitySimuLean/UnitySequenceRunner.cs
@@ -1,0 +1,47 @@
+using UnityEngine;
+
+namespace UnitySimuLean
+{
+    /// <summary>
+    /// Simple simulation runner that configures a <see cref="UnityInfinitySource"/>
+    /// with a predefined sequence of part identifiers and starts the
+    /// simulation. Metrics such as total delay or inspection count can be
+    /// collected by other components and exposed through this runner.
+    /// </summary>
+    public class UnitySequenceRunner : MonoBehaviour, ISimulationRunner
+    {
+        [SerializeField] private UnityInfinitySource source;
+
+        [SerializeField] private float maxTime = 1000f;
+
+        public double TotalDelay { get; private set; }
+
+        public int InspectionCount { get; private set; }
+
+        /// <summary>
+        /// Configures the simulation by assigning the part sequence to the
+        /// source. Resets accumulated metrics.
+        /// </summary>
+        /// <param name="sequence">Sequence of part identifiers.</param>
+        public void Configure(int[] sequence)
+        {
+            if (source != null)
+            {
+                source.SetSequence(sequence);
+            }
+
+            TotalDelay = 0;
+            InspectionCount = 0;
+        }
+
+        /// <summary>
+        /// Starts the simulation. It assumes that <see cref="UnitySimClock"/>
+        /// is present in the scene and will drive the model forward.
+        /// </summary>
+        public void Run()
+        {
+            UnitySimClock.Instance.SimEvents.OnSimStart.Invoke(maxTime);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- allow `InfiniteSource` to accept a predefined item sequence
- expose sequence configuration on `UnityInfinitySource`
- add `UnitySequenceRunner` implementing `ISimulationRunner`

## Testing
- `dotnet build` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a05e0c8d3c832ab76904446c4ddead