### PR TITLE
Add MonoBehaviour wrapper for simulation runner

### DIFF
--- a/Assets/UnitySimuLean/GeneticSequenceTester.cs
+++ b/Assets/UnitySimuLean/GeneticSequenceTester.cs
@@ -7,7 +7,7 @@ namespace UnitySimuLean
         [SerializeField] private int numberOfParts = 10;
         [SerializeField] private int generations = 100;
         [SerializeField] private int populationSize = 50;
-        [SerializeField] private ISimulationRunner simulationRunner;
+        [SerializeField] private UnitySimulationRunnerBehaviour simulationRunner;
 
         private void Start()
         {

--- a/Assets/UnitySimuLean/UnitySimulationRunnerBehaviour.cs
+++ b/Assets/UnitySimuLean/UnitySimulationRunnerBehaviour.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+namespace UnitySimuLean
+{
+    public class UnitySimulationRunnerBehaviour : MonoBehaviour, ISimulationRunner
+    {
+        private readonly UnitySimulationRunner runner = new UnitySimulationRunner();
+
+        public void Configure(int[] sequence) => runner.Configure(sequence);
+
+        public void Run() => runner.Run();
+
+        public double TotalDelay => runner.TotalDelay;
+
+        public int InspectionCount => runner.InspectionCount;
+    }
+}


### PR DESCRIPTION
## Summary
- Enable Unity inspector integration by adding `UnitySimulationRunnerBehaviour` component
- Update `GeneticSequenceTester` to use the new behaviour

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a083cede98832a8df764d6a57ee037