### PR TITLE
feat: map sequence ids to indexes

### DIFF
--- a/Assets/UnitySimuLean/ISimulationRunner.cs
+++ b/Assets/UnitySimuLean/ISimulationRunner.cs
@@ -14,7 +14,7 @@ namespace UnitySimuLean
         /// so that consecutive calls start from the same conditions.
         /// </summary>
         /// <param name="sequence">Sequence of part identifiers.</param>
-        void Configure(int[] sequence);
+        void Configure(string[] sequence);
 
         /// <summary>
         /// Executes the simulation until completion.

--- a/Assets/UnitySimuLean/SequenceChromosome.cs
+++ b/Assets/UnitySimuLean/SequenceChromosome.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using GeneticSharp.Domain.Chromosomes;
 using GeneticSharp.Domain.Randomizations;
@@ -11,18 +12,35 @@ namespace UnitySimuLean
     /// </summary>
     public class SequenceChromosome : ChromosomeBase
     {
+        private readonly string[] idByIndex;
+        private readonly Dictionary<string, int> indexById;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SequenceChromosome"/> class
         /// with a random permutation of part indices.
         /// </summary>
         /// <param name="length">Number of parts in the sequence.</param>
-        public SequenceChromosome(int length) : base(length)
+        public SequenceChromosome(int length)
+            : this(Enumerable.Range(0, length).Select(i => i.ToString()).ToList())
         {
-            var sequence = Enumerable.Range(0, length)
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SequenceChromosome"/> class
+        /// using the provided part identifiers.
+        /// </summary>
+        /// <param name="partIds">List of part identifiers.</param>
+        public SequenceChromosome(IList<string> partIds) : base(partIds.Count)
+        {
+            idByIndex = partIds.ToArray();
+            indexById = partIds.Select((id, idx) => new { id, idx })
+                                .ToDictionary(x => x.id, x => x.idx);
+
+            var sequence = Enumerable.Range(0, partIds.Count)
                                      .OrderBy(_ => RandomizationProvider.Current.GetDouble())
                                      .ToArray();
 
-            for (int i = 0; i < length; i++)
+            for (int i = 0; i < partIds.Count; i++)
             {
                 ReplaceGene(i, new Gene(sequence[i]));
             }
@@ -58,12 +76,12 @@ namespace UnitySimuLean
         }
 
         /// <summary>
-        /// Gets the sequence represented by this chromosome as an array of part indices.
+        /// Gets the sequence represented by this chromosome as an array of part identifiers.
         /// </summary>
         /// <returns>An array representing the part order.</returns>
-        public int[] GetSequence()
+        public string[] GetSequence()
         {
-            return GetGenes().Select(g => (int)g.Value).ToArray();
+            return GetGenes().Select(g => idByIndex[(int)g.Value]).ToArray();
         }
     }
 }

--- a/Assets/UnitySimuLean/SequenceFitness.cs
+++ b/Assets/UnitySimuLean/SequenceFitness.cs
@@ -50,7 +50,7 @@ namespace UnitySimuLean
             }
 
             // 1. Configure simulation with the sequence represented by the chromosome.
-            int[] sequence = seqChromosome.GetSequence();
+            string[] sequence = seqChromosome.GetSequence();
             _runner.Configure(sequence);
 
             // 2. Run the simulation to completion.

--- a/Assets/UnitySimuLean/SequenceOptimizer.cs
+++ b/Assets/UnitySimuLean/SequenceOptimizer.cs
@@ -23,7 +23,7 @@ namespace UnitySimuLean
         /// <param name="generations">Number of generations to evolve.</param>
         /// <param name="populationSize">Population size used by the GA.</param>
         /// <returns>The best sequence of parts discovered.</returns>
-        public static int[] OptimizePartSequence(
+        public static string[] OptimizePartSequence(
             ISimulationRunner runner,
             int numberOfParts,
             int generations = 100,
@@ -60,7 +60,7 @@ namespace UnitySimuLean
                     $"inspection count = {inspectionCount}");
             }
 
-            return bestSequence ?? Array.Empty<int>();
+            return bestSequence ?? Array.Empty<string>();
         }
     }
 }

--- a/Assets/UnitySimuLean/UnitySimulationRunner.cs
+++ b/Assets/UnitySimuLean/UnitySimulationRunner.cs
@@ -23,7 +23,7 @@ namespace UnitySimuLean
         private int _inspectionCount;
 
         /// <inheritdoc />
-        public void Configure(int[] sequence)
+        public void Configure(string[] sequence)
         {
             if (sequence == null)
             {
@@ -43,7 +43,7 @@ namespace UnitySimuLean
                 {"type", new List<string>()}
             };
 
-            foreach (int partId in sequence)
+            foreach (var partId in sequence)
             {
                 // For simplicity all arrivals occur at time 0 with quantity 1 and
                 // a generic name. The important piece of information is the
@@ -51,7 +51,7 @@ namespace UnitySimuLean
                 dataDict["Time"].Add("0");
                 dataDict["Name"].Add("Part");
                 dataDict["Q"].Add("1");
-                dataDict["type"].Add(partId.ToString());
+                dataDict["type"].Add(partId);
             }
 
             // Rebuild source and sink with the new schedule.

--- a/Assets/UnitySimuLean/UnitySimulationRunnerBehaviour.cs
+++ b/Assets/UnitySimuLean/UnitySimulationRunnerBehaviour.cs
@@ -6,7 +6,7 @@ namespace UnitySimuLean
     {
         private readonly UnitySimulationRunner runner = new UnitySimulationRunner();
 
-        public void Configure(int[] sequence) => runner.Configure(sequence);
+        public void Configure(string[] sequence) => runner.Configure(sequence);
 
         public void Run() => runner.Run();
 


### PR DESCRIPTION
## Summary
- support mapping between part identifiers and sequence indexes
- expose original part identifiers when retrieving genetic sequence
- adapt simulation runner pipeline to work with string-based sequences

## Testing
- `mcs Assets/UnitySimuLean/SequenceChromosome.cs` *(fails: The type or namespace name `GeneticSharp` could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a273f3b0832ab888f74c8abfa3e5