### PR TITLE
Expose simulation metrics from fitness evaluations

### DIFF
--- a/Assets/UnitySimuLean/SequenceFitness.cs
+++ b/Assets/UnitySimuLean/SequenceFitness.cs
@@ -1,6 +1,7 @@
 using System;
 using GeneticSharp.Domain.Chromosomes;
 using GeneticSharp.Domain.Fitnesses;
+using System.Collections.Generic;
 
 namespace UnitySimuLean
 {
@@ -13,6 +14,8 @@ namespace UnitySimuLean
     {
         private readonly ISimulationRunner _runner;
         private readonly double _alpha;
+        private readonly Dictionary<IChromosome, (double delay, int inspections)> _metrics =
+            new Dictionary<IChromosome, (double delay, int inspections)>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SequenceFitness"/> class.
@@ -36,13 +39,27 @@ namespace UnitySimuLean
         /// <returns>The fitness value associated with the chromosome.</returns>
         public double Evaluate(IChromosome chromosome)
         {
+            var (fitness, _, _) = EvaluateWithMetrics(chromosome);
+            return fitness;
+        }
+
+        /// <summary>
+        /// Evaluates the chromosome and returns its fitness along with the
+        /// collected performance metrics.
+        /// </summary>
+        /// <param name="chromosome">Chromosome to evaluate.</param>
+        /// <returns>
+        /// A tuple containing the fitness, total delay and inspection count
+        /// obtained from the simulation run.
+        /// </returns>
+        public (double fitness, double totalDelay, int inspectionCount) EvaluateWithMetrics(IChromosome chromosome)
+        {
             if (chromosome == null)
             {
                 throw new ArgumentNullException(nameof(chromosome));
             }
 
-            var seqChromosome = chromosome as SequenceChromosome;
-            if (seqChromosome == null)
+            if (!(chromosome is SequenceChromosome seqChromosome))
             {
                 throw new ArgumentException(
                     "Chromosome must be a SequenceChromosome instance.",
@@ -60,11 +77,23 @@ namespace UnitySimuLean
             double totalDelay = _runner.TotalDelay;
             int inspectionCount = _runner.InspectionCount;
 
+            // Store metrics for later retrieval.
+            _metrics[chromosome] = (totalDelay, inspectionCount);
+
             // 4. Compute a fitness score. Lower delays/inspections yield a higher value.
             double fitness = -(totalDelay + _alpha * inspectionCount);
 
-            // Return the computed fitness.
-            return fitness;
+            return (fitness, totalDelay, inspectionCount);
+        }
+
+        /// <summary>
+        /// Gets the metrics collected for a previously evaluated chromosome.
+        /// </summary>
+        /// <param name="chromosome">Chromosome whose metrics are requested.</param>
+        /// <returns>The delay and inspection count associated with the chromosome.</returns>
+        public (double totalDelay, int inspectionCount) GetMetrics(IChromosome chromosome)
+        {
+            return _metrics.TryGetValue(chromosome, out var m) ? m : (double.NaN, 0);
         }
     }
 }

--- a/Assets/UnitySimuLean/SequenceOptimizer.cs
+++ b/Assets/UnitySimuLean/SequenceOptimizer.cs
@@ -47,20 +47,19 @@ namespace UnitySimuLean
             var bestSequence = bestChromosome?.GetSequence();
             var bestFitness = bestChromosome?.Fitness ?? 0;
 
-            if (bestSequence != null)
+            if (bestChromosome != null && bestSequence != null)
             {
-                runner.Configure(bestSequence);
-                runner.Run();
-                var totalDelay = runner.TotalDelay;
-                var inspectionCount = runner.InspectionCount;
+                var (totalDelay, inspectionCount) = fitness.GetMetrics(bestChromosome);
 
                 Debug.Log(
                     $"Best sequence found: {string.Join(",", bestSequence)} " +
                     $"with fitness = {bestFitness}, total delay = {totalDelay}, " +
                     $"inspection count = {inspectionCount}");
+
+                return bestSequence;
             }
 
-            return bestSequence ?? Array.Empty<string>();
+            return Array.Empty<string>();
         }
     }
 }


### PR DESCRIPTION
## Summary
- cache delay and inspection metrics for chromosomes during fitness evaluation
- reuse cached metrics in OptimizePartSequence instead of re-running the simulation

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68b03d7fd3e4832aadec3b6fc45f7578