### PR TITLE
Allow configuring genetic optimization from the inspector

### DIFF
--- a/Assets/testgenetics/GeneticAlgorithmConfig.cs
+++ b/Assets/testgenetics/GeneticAlgorithmConfig.cs
@@ -1,0 +1,29 @@
+namespace UnitySimuLean
+{
+    /// <summary>
+    /// Selection operators supported by the genetic algorithm.
+    /// </summary>
+    public enum SelectionType
+    {
+        Elite,
+        RouletteWheel
+    }
+
+    /// <summary>
+    /// Crossover operators supported by the genetic algorithm.
+    /// </summary>
+    public enum CrossoverType
+    {
+        Ordered,
+        OnePoint
+    }
+
+    /// <summary>
+    /// Mutation operators supported by the genetic algorithm.
+    /// </summary>
+    public enum MutationType
+    {
+        Twors,
+        ReverseSequence
+    }
+}

--- a/Assets/testgenetics/GeneticAlgorithmConfig.cs.meta
+++ b/Assets/testgenetics/GeneticAlgorithmConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 52d3b75b48e2497592984ca377195b5d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/testgenetics/GeneticSequenceTester.cs
+++ b/Assets/testgenetics/GeneticSequenceTester.cs
@@ -4,18 +4,31 @@ namespace UnitySimuLean
 {
     public class GeneticSequenceTester : MonoBehaviour
     {
+        [SerializeField] private bool enableOptimization = true;
         [SerializeField] private int numberOfParts = 10;
         [SerializeField] private int generations = 100;
         [SerializeField] private int populationSize = 50;
+        [SerializeField] private SelectionType selectionType = SelectionType.Elite;
+        [SerializeField] private CrossoverType crossoverType = CrossoverType.Ordered;
+        [SerializeField] private MutationType mutationType = MutationType.Twors;
         [SerializeField] private UnitySimulationRunnerBehaviour simulationRunner;
 
         private void Start()
         {
-            RunOptimization();
+            if (enableOptimization)
+            {
+                RunOptimization();
+            }
         }
 
+        [ContextMenu("Run Optimization")]
         public void RunOptimization()
         {
+            if (!enableOptimization)
+            {
+                return;
+            }
+
             if (simulationRunner == null)
             {
                 Debug.LogWarning("Simulation runner not assigned.");
@@ -26,7 +39,10 @@ namespace UnitySimuLean
                 simulationRunner,
                 numberOfParts,
                 generations,
-                populationSize);
+                populationSize,
+                selectionType,
+                crossoverType,
+                mutationType);
 
             if (bestSequence.Length > 0)
             {

--- a/Assets/testgenetics/SequenceOptimizer.cs
+++ b/Assets/testgenetics/SequenceOptimizer.cs
@@ -22,19 +22,54 @@ namespace UnitySimuLean
         /// <param name="numberOfParts">Number of parts in the sequence.</param>
         /// <param name="generations">Number of generations to evolve.</param>
         /// <param name="populationSize">Population size used by the GA.</param>
+        /// <param name="selectionType">Selection operator used by the GA.</param>
+        /// <param name="crossoverType">Crossover operator used by the GA.</param>
+        /// <param name="mutationType">Mutation operator used by the GA.</param>
         /// <returns>The best sequence of parts discovered.</returns>
         public static string[] OptimizePartSequence(
             ISimulationRunner runner,
             int numberOfParts,
             int generations = 100,
-            int populationSize = 50)
+            int populationSize = 50,
+            SelectionType selectionType = SelectionType.Elite,
+            CrossoverType crossoverType = CrossoverType.Ordered,
+            MutationType mutationType = MutationType.Twors)
         {
             var fitness = new SequenceFitness(runner);
             var chromosome = new SequenceChromosome(numberOfParts);
             var population = new Population(populationSize, populationSize * 2, chromosome);
-            var selection = new EliteSelection();
-            var crossover = new OrderedCrossover();
-            var mutation = new TworsMutation();
+            ISelection selection;
+            switch (selectionType)
+            {
+                case SelectionType.RouletteWheel:
+                    selection = new RouletteWheelSelection();
+                    break;
+                default:
+                    selection = new EliteSelection();
+                    break;
+            }
+
+            ICrossover crossover;
+            switch (crossoverType)
+            {
+                case CrossoverType.OnePoint:
+                    crossover = new OnePointCrossover();
+                    break;
+                default:
+                    crossover = new OrderedCrossover();
+                    break;
+            }
+
+            IMutation mutation;
+            switch (mutationType)
+            {
+                case MutationType.ReverseSequence:
+                    mutation = new ReverseSequenceMutation();
+                    break;
+                default:
+                    mutation = new TworsMutation();
+                    break;
+            }
 
             var ga = new GeneticAlgorithm(population, fitness, selection, crossover, mutation)
             {


### PR DESCRIPTION
## Summary
- Add enums to select GA operators from the inspector
- Support operator choices in `SequenceOptimizer`
- Expose optimization toggle and configuration fields in `GeneticSequenceTester`

## Testing
- `mcs Assets/testgenetics/*.cs Assets/UnitySimuLean/UnitySimulationRunnerBehaviour.cs -r:Assets/Packages/GeneticSharp.2.6.0/lib/netstandard2.0/GeneticSharp.Domain.dll -r:Assets/Packages/GeneticSharp.2.6.0/lib/netstandard2.0/GeneticSharp.Infrastructure.Framework.dll` *(fails: UnityEngine namespace not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b04168fc48832aa8783c5179f62aff