### PR TITLE
feat: expose visual source and sink

### DIFF
--- a/Assets/UnitySimuLean/UnitySimulationRunner.cs
+++ b/Assets/UnitySimuLean/UnitySimulationRunner.cs
@@ -19,6 +19,20 @@ namespace UnitySimuLean
         private ScheduleSource _source;
         private Sink _sink;
 
+        /// <summary>
+        /// Optional visual representation for the initial <see cref="ScheduleSource"/>.
+        /// When set, generated items will use this <see cref="VElement"/> instead of a
+        /// headless <see cref="NullVElement"/>.
+        /// </summary>
+        public VElement SourceView { get; set; }
+
+        /// <summary>
+        /// Optional visual representation for the final <see cref="Sink"/>.
+        /// When set, items leaving the model will interact with this
+        /// <see cref="VElement"/>.
+        /// </summary>
+        public VElement SinkView { get; set; }
+
         private double _totalDelay;
         private int _inspectionCount;
 
@@ -54,9 +68,17 @@ namespace UnitySimuLean
                 dataDict["type"].Add(partId);
             }
 
-            // Rebuild source and sink with the new schedule.
-            _source = new ScheduleSource("Source", _clock, null, dataDict, null, null);
-            _sink = new Sink("Sink", _clock);
+            // Rebuild source and sink with the new schedule. Attach provided
+            // visual elements when available so that items can be observed in
+            // the Unity scene. Fall back to headless execution otherwise.
+            _source = new ScheduleSource("Source", _clock, null, dataDict, null, null)
+            {
+                vElement = SourceView ?? new NullVElement()
+            };
+            _sink = new Sink("Sink", _clock)
+            {
+                vElement = SinkView ?? new NullVElement()
+            };
             GeneralLink.CreateLink(_source, new List<Element> { _sink });
 
             // Reset metrics.

--- a/Assets/UnitySimuLean/UnitySimulationRunnerBehaviour.cs
+++ b/Assets/UnitySimuLean/UnitySimulationRunnerBehaviour.cs
@@ -4,9 +4,17 @@ namespace UnitySimuLean
 {
     public class UnitySimulationRunnerBehaviour : MonoBehaviour, ISimulationRunner
     {
+        [SerializeField] private UnityScheduleSource source;
+        [SerializeField] private UnitySink sink;
+
         private readonly UnitySimulationRunner runner = new UnitySimulationRunner();
 
-        public void Configure(string[] sequence) => runner.Configure(sequence);
+        public void Configure(string[] sequence)
+        {
+            runner.SourceView = source;
+            runner.SinkView = sink;
+            runner.Configure(sequence);
+        }
 
         public void Run() => runner.Run();
 


### PR DESCRIPTION
## Summary
- allow UnitySimulationRunner to use provided source/sink visual elements
- add inspector fields on UnitySimulationRunnerBehaviour to drag-and-drop source and sink

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0467d3a7c832a9e6f128ab26a1777