### PR TITLE
Clear metrics after retrieval in SequenceFitness

### DIFF
--- a/Assets/testgenetics/SequenceFitness.cs
+++ b/Assets/testgenetics/SequenceFitness.cs
@@ -93,7 +93,17 @@ namespace UnitySimuLean
         /// <returns>The delay and inspection count associated with the chromosome.</returns>
         public (double totalDelay, int inspectionCount) GetMetrics(IChromosome chromosome)
         {
-            return _metrics.TryGetValue(chromosome, out var m) ? m : (double.NaN, 0);
+            if (_metrics.TryGetValue(chromosome, out var metrics))
+            {
+                // Remove metrics from previous chromosomes to avoid uncontrolled
+                // growth of the dictionary. Retain only the metrics for the
+                // requested chromosome so they remain available if needed again.
+                _metrics.Clear();
+                _metrics[chromosome] = metrics;
+                return metrics;
+            }
+
+            return (double.NaN, 0);
         }
     }
 }


### PR DESCRIPTION
## Summary
- purge previously stored chromosome metrics upon retrieval to prevent dictionary growth

## Testing
- `dotnet build` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b076603e20832abcda984901fff4e8