### PR TITLE
Record delay count in experiment CSV

### DIFF
--- a/Assets/SimuLean.Net/SimElements/ServerProcess.cs
+++ b/Assets/SimuLean.Net/SimElements/ServerProcess.cs
@@ -11,6 +11,8 @@ namespace SimuLean
         public double loadTime = 0.0;
         public double lastDelay = 0.0;
 
+        public static int TotalDelays { get; private set; } = 0;
+
         int capacity;
 
         DoubleRandomProcess delay;
@@ -39,10 +41,15 @@ namespace SimuLean
             typeItem = 0;
         }
 
+        public static void ResetDelays()
+        {
+            TotalDelays = 0;
+        }
+
         public double GetDelay()
         {
             double delay = this.delay.NextValue();
-
+            TotalDelays++;
             return delay;
         }
 

--- a/Assets/UnitySimuLean/Experimenter.cs
+++ b/Assets/UnitySimuLean/Experimenter.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnitySimuLean.Utilities;
+using SimuLean;
 
 namespace UnitySimuLean
 {
@@ -52,6 +53,7 @@ namespace UnitySimuLean
         {
             currentScenario = 0;
             this.SetScenario(currentScenario);
+            ServerProcess.ResetDelays();
             UnitySimClock.Instance.SimEvents.OnSimStart.Invoke(maxTime);
 
             UnitySimClock.Instance.SetTimeScale(this.timeScale);
@@ -150,6 +152,8 @@ namespace UnitySimuLean
                 fileWriter.AddText(new string[] { (currentScenario - 1).ToString(), oElements[i].name, Variables[i], GetPropertyValue(oElements[i], Variables[i]).ToString() });
 
             }
+            fileWriter.AddText(new string[] { (currentScenario - 1).ToString(), "System", "Delays", ServerProcess.TotalDelays.ToString() });
+            ServerProcess.ResetDelays();
 
             if (!SetScenario(currentScenario))
                 this.FinishExperiment();


### PR DESCRIPTION
## Summary
- count total processing delays in `ServerProcess`
- reset delay counter between scenarios
- export total delays per scenario to CSV in `Experimenter`

## Testing
- `dotnet build` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b1987aac0c832a9c40d16cc8b21410