### PR TITLE
Expose sink delay count for genetic optimization

### DIFF
--- a/Assets/UnitySimuLean/ISimulationRunner.cs
+++ b/Assets/UnitySimuLean/ISimulationRunner.cs
@@ -22,9 +22,9 @@ namespace UnitySimuLean
         void Run();
 
         /// <summary>
-        /// Gets the accumulated delay for the last executed simulation.
+        /// Gets the number of delayed items from the last executed simulation.
         /// </summary>
-        double TotalDelay { get; }
+        int DelayCount { get; }
 
         /// <summary>
         /// Gets the number of inspections performed during the last run.

--- a/Assets/UnitySimuLean/UnitySimulationRunner.cs
+++ b/Assets/UnitySimuLean/UnitySimulationRunner.cs
@@ -33,7 +33,7 @@ namespace UnitySimuLean
         /// </summary>
         public VElement SinkView { get; set; }
 
-        private double _totalDelay;
+        private int _delayCount;
         private int _inspectionCount;
 
         /// <inheritdoc />
@@ -82,7 +82,7 @@ namespace UnitySimuLean
             GeneralLink.CreateLink(_source, new List<Element> { _sink });
 
             // Reset metrics.
-            _totalDelay = 0.0;
+            _delayCount = 0;
             _inspectionCount = 0;
         }
 
@@ -103,12 +103,12 @@ namespace UnitySimuLean
             }
 
             // Collect metrics from the sink.
-            _totalDelay = _sink.GetRetrasados();
+            _delayCount = _sink.GetRetrasados();
             _inspectionCount = _sink.GetInspecciones();
         }
 
         /// <inheritdoc />
-        public double TotalDelay => _totalDelay;
+        public int DelayCount => _delayCount;
 
         /// <inheritdoc />
         public int InspectionCount => _inspectionCount;

--- a/Assets/UnitySimuLean/UnitySimulationRunnerBehaviour.cs
+++ b/Assets/UnitySimuLean/UnitySimulationRunnerBehaviour.cs
@@ -18,7 +18,7 @@ namespace UnitySimuLean
 
         public void Run() => runner.Run();
 
-        public double TotalDelay => runner.TotalDelay;
+        public int DelayCount => runner.DelayCount;
 
         public int InspectionCount => runner.InspectionCount;
     }

--- a/Assets/testgenetics/GeneticSequenceTester.cs
+++ b/Assets/testgenetics/GeneticSequenceTester.cs
@@ -32,7 +32,9 @@ namespace UnitySimuLean
         [SerializeField]
         private int generations = 100;
         [Tooltip("Population size per generation.")]
-        [Min(1)]
+        // GeneticSharp requires at least two chromosomes per generation.
+        // Enforce a minimum of 2 in the inspector to prevent runtime errors.
+        [Min(2)]
         [SerializeField]
         private int populationSize = 50;
 

--- a/Assets/testgenetics/GeneticSequenceTester.cs
+++ b/Assets/testgenetics/GeneticSequenceTester.cs
@@ -97,13 +97,13 @@ namespace UnitySimuLean
                 crossType,
                 mutType);
 
-            var (bestSequence, totalDelay, inspectionCount) = result;
+            var (bestSequence, delayCount, inspectionCount) = result;
 
             if (bestSequence.Length > 0)
             {
                 Debug.Log($"Optimized sequence: {string.Join(",", bestSequence)}");
-                Debug.Log($"Total delay: {totalDelay}, inspection count: {inspectionCount}");
-                WriteResultsToCsv(bestSequence, totalDelay, inspectionCount);
+                Debug.Log($"Delay count: {delayCount}, inspection count: {inspectionCount}");
+                WriteResultsToCsv(bestSequence, delayCount, inspectionCount);
             }
             else
             {
@@ -121,18 +121,18 @@ namespace UnitySimuLean
             }
         }
 
-        private void WriteResultsToCsv(string[] sequence, double totalDelay, int inspectionCount)
+        private void WriteResultsToCsv(string[] sequence, int delayCount, int inspectionCount)
         {
             var logsPath = Path.Combine(Application.dataPath, "..", "Logs");
             Directory.CreateDirectory(logsPath);
             var csvPath = Path.Combine(logsPath, CsvFileName);
             if (!File.Exists(csvPath))
             {
-                File.WriteAllText(csvPath, "Sequence,TotalDelay,InspectionCount\n");
+                File.WriteAllText(csvPath, "Sequence,DelayCount,InspectionCount\n");
             }
 
             var sequenceValue = string.Join(",", sequence);
-            var line = $"\"{sequenceValue}\",{totalDelay},{inspectionCount}\n";
+            var line = $"\"{sequenceValue}\",{delayCount},{inspectionCount}\n";
             File.AppendAllText(csvPath, line);
             Debug.Log($"Results written to {csvPath}");
         }

--- a/Assets/testgenetics/SequenceFitness.cs
+++ b/Assets/testgenetics/SequenceFitness.cs
@@ -14,8 +14,8 @@ namespace UnitySimuLean
     {
         private readonly ISimulationRunner _runner;
         private readonly double _alpha;
-        private readonly Dictionary<IChromosome, (double delay, int inspections)> _metrics =
-            new Dictionary<IChromosome, (double delay, int inspections)>();
+        private readonly Dictionary<IChromosome, (int delay, int inspections)> _metrics =
+            new Dictionary<IChromosome, (int delay, int inspections)>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SequenceFitness"/> class.
@@ -49,10 +49,10 @@ namespace UnitySimuLean
         /// </summary>
         /// <param name="chromosome">Chromosome to evaluate.</param>
         /// <returns>
-        /// A tuple containing the fitness, total delay and inspection count
+        /// A tuple containing the fitness, delay count and inspection count
         /// obtained from the simulation run.
         /// </returns>
-        public (double fitness, double totalDelay, int inspectionCount) EvaluateWithMetrics(IChromosome chromosome)
+        public (double fitness, int delayCount, int inspectionCount) EvaluateWithMetrics(IChromosome chromosome)
         {
             if (chromosome == null)
             {
@@ -74,24 +74,24 @@ namespace UnitySimuLean
             _runner.Run();
 
             // 3. Collect performance metrics from the simulation.
-            double totalDelay = _runner.TotalDelay;
+            int delayCount = _runner.DelayCount;
             int inspectionCount = _runner.InspectionCount;
 
             // Store metrics for later retrieval.
-            _metrics[chromosome] = (totalDelay, inspectionCount);
+            _metrics[chromosome] = (delayCount, inspectionCount);
 
             // 4. Compute a fitness score. Lower delays/inspections yield a higher value.
-            double fitness = -(totalDelay + _alpha * inspectionCount);
+            double fitness = -(delayCount + _alpha * inspectionCount);
 
-            return (fitness, totalDelay, inspectionCount);
+            return (fitness, delayCount, inspectionCount);
         }
 
         /// <summary>
         /// Gets the metrics collected for a previously evaluated chromosome.
         /// </summary>
         /// <param name="chromosome">Chromosome whose metrics are requested.</param>
-        /// <returns>The delay and inspection count associated with the chromosome.</returns>
-        public (double totalDelay, int inspectionCount) GetMetrics(IChromosome chromosome)
+        /// <returns>The delay count and inspection count associated with the chromosome.</returns>
+        public (int delayCount, int inspectionCount) GetMetrics(IChromosome chromosome)
         {
             if (_metrics.TryGetValue(chromosome, out var metrics))
             {
@@ -103,7 +103,7 @@ namespace UnitySimuLean
                 return metrics;
             }
 
-            return (double.NaN, 0);
+            return (0, 0);
         }
     }
 }

--- a/Assets/testgenetics/SequenceOptimizer.cs
+++ b/Assets/testgenetics/SequenceOptimizer.cs
@@ -27,11 +27,11 @@ namespace UnitySimuLean
         /// <param name="crossoverType">Crossover operator used by the GA.</param>
         /// <param name="mutationType">Mutation operator used by the GA.</param>
         /// <returns>
-        /// A tuple containing the best sequence, its total delay and inspection
+        /// A tuple containing the best sequence, its delay count and inspection
         /// count. If no sequence is found an empty sequence and default metrics
         /// are returned.
         /// </returns>
-        public static (string[] bestSequence, double totalDelay, int inspectionCount) OptimizePartSequence(
+        public static (string[] bestSequence, int delayCount, int inspectionCount) OptimizePartSequence(
             ISimulationRunner runner,
             int numberOfParts,
             int generations = 100,
@@ -86,19 +86,19 @@ namespace UnitySimuLean
             var bestChromosome = ga.BestChromosome as SequenceChromosome;
             if (bestChromosome == null)
             {
-                return (Array.Empty<string>(), double.NaN, 0);
+                return (Array.Empty<string>(), 0, 0);
             }
 
             var bestSequence = bestChromosome.GetSequence();
             var bestFitness = bestChromosome.Fitness ?? 0;
-            var (totalDelay, inspectionCount) = fitness.GetMetrics(bestChromosome);
+            var (delayCount, inspectionCount) = fitness.GetMetrics(bestChromosome);
 
             Debug.Log(
                 $"Best sequence found: {string.Join(",", bestSequence)} " +
-                $"with fitness = {bestFitness}, total delay = {totalDelay}, " +
+                $"with fitness = {bestFitness}, delay count = {delayCount}, " +
                 $"inspection count = {inspectionCount}");
 
-            return (bestSequence, totalDelay, inspectionCount);
+            return (bestSequence, delayCount, inspectionCount);
         }
     }
 }

--- a/Assets/testgenetics/SequenceOptimizer.cs
+++ b/Assets/testgenetics/SequenceOptimizer.cs
@@ -40,6 +40,11 @@ namespace UnitySimuLean
             CrossoverType crossoverType = CrossoverType.Ordered,
             MutationType mutationType = MutationType.Twors)
         {
+            // GeneticSharp requires at least two chromosomes per generation.
+            // Clamp the population size to the minimum allowed value to avoid
+            // runtime exceptions when a smaller value is provided.
+            populationSize = Math.Max(2, populationSize);
+
             var fitness = new SequenceFitness(runner);
             var chromosome = new SequenceChromosome(numberOfParts);
             var population = new Population(populationSize, populationSize * 2, chromosome);


### PR DESCRIPTION
## Summary
- expose delayed item count via `ISimulationRunner` and `UnitySimulationRunner`
- refactor genetic algorithm helpers to use delay count instead of double delay
- log and persist delay count in optimization results

## Testing
- ⚠️ `dotnet test` *(dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1998ac354832aab67ef227d6c0814