### PR TITLE
Fix GA population size check

### DIFF
--- a/Assets/testgenetics/GeneticSequenceTester.cs
+++ b/Assets/testgenetics/GeneticSequenceTester.cs
@@ -32,7 +32,9 @@ namespace UnitySimuLean
         [SerializeField]
         private int generations = 100;
         [Tooltip("Population size per generation.")]
-        [Min(1)]
+        // GeneticSharp requires at least two chromosomes per generation.
+        // Enforce a minimum of 2 in the inspector to prevent runtime errors.
+        [Min(2)]
         [SerializeField]
         private int populationSize = 50;
 

--- a/Assets/testgenetics/SequenceOptimizer.cs
+++ b/Assets/testgenetics/SequenceOptimizer.cs
@@ -40,6 +40,11 @@ namespace UnitySimuLean
             CrossoverType crossoverType = CrossoverType.Ordered,
             MutationType mutationType = MutationType.Twors)
         {
+            // GeneticSharp requires at least two chromosomes per generation.
+            // Clamp the population size to the minimum allowed value to avoid
+            // runtime exceptions when a smaller value is provided.
+            populationSize = Math.Max(2, populationSize);
+
             var fitness = new SequenceFitness(runner);
             var chromosome = new SequenceChromosome(numberOfParts);
             var population = new Population(populationSize, populationSize * 2, chromosome);


### PR DESCRIPTION
## Summary
- Clamp GA population size to at least 2 chromosomes to avoid runtime exception
- Require minimum population size of 2 in genetic tester inspector

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ad3dbfd4832ab8e795a5c27c1a29