### PR TITLE
Limit genetic optimization to delay reduction

### DIFF
--- a/Assets/testgenetics/SequenceFitness.cs
+++ b/Assets/testgenetics/SequenceFitness.cs
@@ -13,7 +13,7 @@ namespace UnitySimuLean
     public class SequenceFitness : IFitness
     {
         private readonly ISimulationRunner _runner;
-        private readonly double _alpha;
+        private readonly int _requiredInspectionCount;
         private readonly Dictionary<IChromosome, (int delay, int inspections)> _metrics =
             new Dictionary<IChromosome, (int delay, int inspections)>();
 
@@ -21,14 +21,15 @@ namespace UnitySimuLean
         /// Initializes a new instance of the <see cref="SequenceFitness"/> class.
         /// </summary>
         /// <param name="runner">Simulation runner used to evaluate sequences.</param>
-        /// <param name="alpha">
-        /// Weight applied to the inspection count when computing the fitness
-        /// value. Defaults to 1.
+        /// <param name="requiredInspectionCount">
+        /// Number of inspections that must remain constant across evaluations.
+        /// Any chromosome producing a different value will receive the worst
+        /// possible fitness.
         /// </param>
-        public SequenceFitness(ISimulationRunner runner, double alpha = 1.0)
+        public SequenceFitness(ISimulationRunner runner, int requiredInspectionCount)
         {
             _runner = runner ?? throw new ArgumentNullException(nameof(runner));
-            _alpha = alpha;
+            _requiredInspectionCount = requiredInspectionCount;
         }
 
         /// <summary>
@@ -80,8 +81,10 @@ namespace UnitySimuLean
             // Store metrics for later retrieval.
             _metrics[chromosome] = (delayCount, inspectionCount);
 
-            // 4. Compute a fitness score. Lower delays/inspections yield a higher value.
-            double fitness = -(delayCount + _alpha * inspectionCount);
+            // 4. Compute a fitness score. Any change in inspection count is heavily penalised.
+            double fitness = inspectionCount == _requiredInspectionCount
+                ? -delayCount
+                : double.MinValue;
 
             return (fitness, delayCount, inspectionCount);
         }

--- a/Assets/testgenetics/SequenceOptimizer.cs
+++ b/Assets/testgenetics/SequenceOptimizer.cs
@@ -45,7 +45,17 @@ namespace UnitySimuLean
             // runtime exceptions when a smaller value is provided.
             populationSize = Math.Max(2, populationSize);
 
-            var fitness = new SequenceFitness(runner);
+            // Run a baseline simulation to determine the required number of inspections.
+            var baselineSequence = new string[numberOfParts];
+            for (int i = 0; i < numberOfParts; i++)
+            {
+                baselineSequence[i] = i.ToString();
+            }
+            runner.Configure(baselineSequence);
+            runner.Run();
+            var requiredInspectionCount = runner.InspectionCount;
+
+            var fitness = new SequenceFitness(runner, requiredInspectionCount);
             var chromosome = new SequenceChromosome(numberOfParts);
             var population = new Population(populationSize, populationSize * 2, chromosome);
             ISelection selection;


### PR DESCRIPTION
## Summary
- penalize sequences that alter inspection count and score fitness only on delays
- run baseline simulation to capture expected inspection count before GA execution

## Testing
- `dotnet build` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c07b8bcc832a8854b442f03b4f60