### PR TITLE
1Optimize schedule priorities with genetic algorithm

### DIFF
--- a/Assets/testgenetics/SchedulePriorityOptimizer.cs
+++ b/Assets/testgenetics/SchedulePriorityOptimizer.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace UnitySimuLean
+{
+    /// <summary>
+    /// Helper class that reads a schedule file, applies a genetic algorithm to
+    /// minimise delays by reordering priorities and writes the optimised
+    /// schedule and metrics to CSV files.
+    /// </summary>
+    public static class SchedulePriorityOptimizer
+    {
+        /// <summary>
+        /// Optimises the schedule found at <paramref name="inputCsv"/> and
+        /// writes the updated schedule (with new priorities) to
+        /// <paramref name="outputSchedule"/>. A separate CSV containing the
+        /// delay and inspection counts is written to
+        /// <paramref name="outputStats"/>.
+        /// </summary>
+        public static void Optimise(string inputCsv, string outputSchedule, string outputStats,
+            int generations = 100, int populationSize = 50)
+        {
+            if (string.IsNullOrEmpty(inputCsv))
+            {
+                throw new ArgumentException("Input path required", nameof(inputCsv));
+            }
+
+            var (headers, dataDict) = LoadSchedule(inputCsv);
+            if (!dataDict.ContainsKey("Referencia"))
+            {
+                throw new InvalidOperationException("Schedule must contain a 'Referencia' column.");
+            }
+
+            var referencias = dataDict["Referencia"];            
+            var runner = new ScheduleSimulationRunner(dataDict, headers);
+            var (bestSequence, delay, inspections) =
+                SequenceOptimizer.OptimizePartSequence(runner, referencias, generations, populationSize);
+
+            WriteOptimisedSchedule(outputSchedule, headers, dataDict, bestSequence);
+            WriteStats(outputStats, delay, inspections);
+        }
+
+        // Loads a CSV schedule into a header list and data dictionary.
+        private static (List<string> headers, Dictionary<string, List<string>> dataDict) LoadSchedule(string path)
+        {
+            var lines = File.ReadAllLines(path);
+            if (lines.Length == 0)
+            {
+                throw new InvalidOperationException("Schedule file is empty.");
+            }
+            var headers = new List<string>(lines[0].Split(','));
+            var dict = new Dictionary<string, List<string>>();
+            foreach (var h in headers)
+            {
+                dict[h] = new List<string>();
+            }
+            for (int i = 1; i < lines.Length; i++)
+            {
+                if (string.IsNullOrWhiteSpace(lines[i])) continue;
+                var values = lines[i].Split(',');
+                for (int c = 0; c < headers.Count && c < values.Length; c++)
+                {
+                    dict[headers[c]].Add(values[c]);
+                }
+            }
+            return (headers, dict);
+        }
+
+        // Writes the optimised schedule with updated priorities and order.
+        private static void WriteOptimisedSchedule(string path, List<string> headers,
+            Dictionary<string, List<string>> baseData, string[] sequence)
+        {
+            var indexByRef = new Dictionary<string, int>();
+            var referencias = baseData["Referencia"];
+            for (int i = 0; i < referencias.Count; i++)
+            {
+                indexByRef[referencias[i]] = i;
+            }
+
+            using (var writer = new StreamWriter(path))
+            {
+                writer.WriteLine(string.Join(",", headers));
+                int priority = 1;
+                foreach (var refId in sequence)
+                {
+                    int idx = indexByRef[refId];
+                    var row = new List<string>();
+                    foreach (var h in headers)
+                    {
+                        string value = baseData[h][idx];
+                        if (h.Equals("Priority", StringComparison.OrdinalIgnoreCase) ||
+                            h.Equals("priorities", StringComparison.OrdinalIgnoreCase))
+                        {
+                            value = priority.ToString();
+                        }
+                        row.Add(value);
+                    }
+                    writer.WriteLine(string.Join(",", row));
+                    priority++;
+                }
+            }
+        }
+
+        // Writes delay and inspection counts to a simple CSV.
+        private static void WriteStats(string path, int delay, int inspections)
+        {
+            using (var writer = new StreamWriter(path))
+            {
+                writer.WriteLine("Metric,Value");
+                writer.WriteLine($"Delays,{delay}");
+                writer.WriteLine($"Inspections,{inspections}");
+            }
+        }
+    }
+}

--- a/Assets/testgenetics/ScheduleSimulationRunner.cs
+++ b/Assets/testgenetics/ScheduleSimulationRunner.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using SimuLean;
+
+namespace UnitySimuLean
+{
+    /// <summary>
+    /// Simulation runner that executes a model based on a schedule loaded
+    /// from a data dictionary. The dictionary maps column headers to lists of
+    /// values. During configuration the entries are reordered according to the
+    /// provided sequence of reference identifiers, allowing genetic algorithms
+    /// to evaluate different priority orders.
+    /// </summary>
+    public class ScheduleSimulationRunner : ISimulationRunner
+    {
+        private readonly Dictionary<string, List<string>> _baseData;
+        private readonly List<string> _headers;
+        private readonly SimClock _clock = new SimClock();
+        private ScheduleSource _source;
+        private Sink _sink;
+        private int _delayCount;
+        private int _inspectionCount;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScheduleSimulationRunner"/> class.
+        /// </summary>
+        /// <param name="baseData">Schedule data indexed by column header.</param>
+        /// <param name="headers">Original header order for CSV reconstruction.</param>
+        public ScheduleSimulationRunner(Dictionary<string, List<string>> baseData, List<string> headers)
+        {
+            _baseData = baseData ?? throw new ArgumentNullException(nameof(baseData));
+            _headers = headers ?? throw new ArgumentNullException(nameof(headers));
+        }
+
+        /// <inheritdoc />
+        public void Configure(string[] sequence)
+        {
+            if (sequence == null)
+            {
+                throw new ArgumentNullException(nameof(sequence));
+            }
+
+            // Reset previous model state.
+            _clock.Reset();
+            Element.GetElements().Clear();
+
+            // Prepare a new data dictionary reordered according to the sequence
+            // of references. Also assign sequential priorities reflecting the
+            // new order.
+            var dataDict = new Dictionary<string, List<string>>();
+            foreach (var h in _headers)
+            {
+                dataDict[h] = new List<string>();
+            }
+
+            // Map reference to row index for quick lookup.
+            var referencias = _baseData["Referencia"];
+            var indexByRef = new Dictionary<string, int>();
+            for (int i = 0; i < referencias.Count; i++)
+            {
+                indexByRef[referencias[i]] = i;
+            }
+
+            int priority = 1;
+            foreach (var refId in sequence)
+            {
+                int idx = indexByRef[refId];
+                foreach (var h in _headers)
+                {
+                    string value = _baseData[h][idx];
+                    if (h.Equals("Priority", StringComparison.OrdinalIgnoreCase) ||
+                        h.Equals("priorities", StringComparison.OrdinalIgnoreCase))
+                    {
+                        dataDict[h].Add(priority.ToString());
+                    }
+                    else
+                    {
+                        dataDict[h].Add(value);
+                    }
+                }
+                priority++;
+            }
+
+            _source = new ScheduleSource("Source", _clock, null, dataDict, null, null, autoSort: false)
+            {
+                vElement = new NullVElement()
+            };
+            _sink = new Sink("Sink", _clock)
+            {
+                vElement = new NullVElement()
+            };
+            GeneralLink.CreateLink(_source, new List<Element> { _sink });
+            _delayCount = 0;
+            _inspectionCount = 0;
+        }
+
+        /// <inheritdoc />
+        public void Run()
+        {
+            if (_source == null || _sink == null)
+            {
+                throw new InvalidOperationException("Runner must be configured before running.");
+            }
+
+            _source.Start();
+            _sink.Start();
+            while (_clock.AdvanceClock(double.MaxValue))
+            {
+                // Process events until none remain.
+            }
+            _delayCount = _sink.GetRetrasados();
+            _inspectionCount = _sink.GetInspecciones();
+        }
+
+        /// <inheritdoc />
+        public int DelayCount => _delayCount;
+
+        /// <inheritdoc />
+        public int InspectionCount => _inspectionCount;
+    }
+}

--- a/Assets/testgenetics/SequenceOptimizer.cs
+++ b/Assets/testgenetics/SequenceOptimizer.cs
@@ -115,6 +115,93 @@ namespace UnitySimuLean
 
             return (bestSequence, delayCount, inspectionCount);
         }
+
+        /// <summary>
+        /// Runs a Genetic Algorithm and returns the best sequence found for a
+        /// set of explicit part identifiers. This overload is useful when the
+        /// parts are not simply indexed from 0..N but have meaningful
+        /// identifiers such as references from a production schedule.
+        /// </summary>
+        /// <param name="runner">Simulation runner used to evaluate sequences.</param>
+        /// <param name="partIds">Identifiers of the parts to arrange.</param>
+        /// <param name="generations">Number of generations to evolve.</param>
+        /// <param name="populationSize">Population size used by the GA.</param>
+        /// <param name="selectionType">Selection operator used by the GA.</param>
+        /// <param name="crossoverType">Crossover operator used by the GA.</param>
+        /// <param name="mutationType">Mutation operator used by the GA.</param>
+        /// <returns>
+        /// A tuple containing the best sequence, its delay count and inspection
+        /// count. If no sequence is found an empty sequence and default metrics
+        /// are returned.
+        /// </returns>
+        public static (string[] bestSequence, int delayCount, int inspectionCount) OptimizePartSequence(
+            ISimulationRunner runner,
+            IList<string> partIds,
+            int generations = 100,
+            int populationSize = 50,
+            SelectionType selectionType = SelectionType.Elite,
+            CrossoverType crossoverType = CrossoverType.Ordered,
+            MutationType mutationType = MutationType.Twors)
+        {
+            if (partIds == null)
+            {
+                throw new ArgumentNullException(nameof(partIds));
+            }
+
+            // Ensure a valid population size for GeneticSharp.
+            populationSize = Math.Max(2, populationSize);
+
+            // Determine the required number of inspections from a baseline run
+            // using the provided sequence in its original order.
+            var baselineSequence = partIds.ToArray();
+            runner.Configure(baselineSequence);
+            runner.Run();
+            var requiredInspectionCount = runner.InspectionCount;
+
+            var fitness = new SequenceFitness(runner, requiredInspectionCount);
+            var chromosome = new SequenceChromosome(partIds);
+            var population = new Population(populationSize, populationSize * 2, chromosome);
+
+            ISelection selection = selectionType switch
+            {
+                SelectionType.RouletteWheel => new RouletteWheelSelection(),
+                _ => new EliteSelection(),
+            };
+
+            ICrossover crossover = crossoverType switch
+            {
+                CrossoverType.OnePoint => new OnePointCrossover(),
+                _ => new OrderedCrossover(),
+            };
+
+            IMutation mutation = mutationType switch
+            {
+                MutationType.ReverseSequence => new ReverseSequenceMutation(),
+                _ => new TworsMutation(),
+            };
+
+            var ga = new GeneticAlgorithm(population, fitness, selection, crossover, mutation)
+            {
+                Termination = new GenerationNumberTermination(generations)
+            };
+
+            ga.Start();
+
+            var bestChromosome = ga.BestChromosome as SequenceChromosome;
+            if (bestChromosome == null)
+            {
+                return (Array.Empty<string>(), 0, 0);
+            }
+
+            var bestSequence = bestChromosome.GetSequence();
+            var (delayCount, inspectionCount) = fitness.GetMetrics(bestChromosome);
+
+            Debug.Log(
+                $"Best sequence found: {string.Join(",", bestSequence)} " +
+                $"with delay count = {delayCount}, inspection count = {inspectionCount}");
+
+            return (bestSequence, delayCount, inspectionCount);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add SchedulePriorityOptimizer to read schedules, run genetic optimization and export results
- support explicit part identifiers in SequenceOptimizer
- implement ScheduleSimulationRunner to run schedules with reordered priorities

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7548e15a8832ab127f853c327b454