### PR TITLE
Fix SequenceChromosome CreateNew using original part identifiers

### DIFF
--- a/Assets/testgenetics/SequenceChromosome.cs
+++ b/Assets/testgenetics/SequenceChromosome.cs
@@ -73,7 +73,14 @@ namespace UnitySimuLean
         /// <returns>A new SequenceChromosome.</returns>
         public override IChromosome CreateNew()
         {
-            return new SequenceChromosome(Length);
+            // Preserve the original part identifiers when creating
+            // a new chromosome so that subsequent generations
+            // continue to reference valid schedule entries instead
+            // of falling back to numeric identifiers ("0", "1", ...).
+            // Using the existing idByIndex array ensures that the
+            // mapping between gene indices and part references is
+            // maintained across generations.
+            return new SequenceChromosome(idByIndex);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- preserve part IDs when creating new sequence chromosomes so GA generations reference valid schedule entries

## Testing
- `dotnet test` *(fails: MSB1003: specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b7631371d4832a94bbb7049b7f3322