### PR TITLE
Fix missing IList compile error in SequenceOptimizer

### DIFF
--- a/Assets/testgenetics/SequenceOptimizer.cs
+++ b/Assets/testgenetics/SequenceOptimizer.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using GeneticSharp.Domain;
 using GeneticSharp.Domain.Populations;
 using GeneticSharp.Domain.Selections;


### PR DESCRIPTION
## Summary
- add System.Collections.Generic and System.Linq imports to SequenceOptimizer

## Testing
- `mono-csc Assets/testgenetics/SequenceOptimizer.cs` *(fails: Unexpected symbol `switch`)*

------
https://chatgpt.com/codex/tasks/task_e_68b763887f94832aaea2949fa7704d20