### PR TITLE
Ensure GA chromosomes retain valid part identifiers

### DIFF
--- a/Assets/testgenetics/SequenceChromosome.cs
+++ b/Assets/testgenetics/SequenceChromosome.cs
@@ -68,12 +68,15 @@ namespace UnitySimuLean
         }
 
         /// <summary>
-        /// Creates a new instance of the chromosome with the same length.
+        /// Creates a new instance of the chromosome preserving the same set
+        /// of part identifiers. This ensures that chromosomes produced by the
+        /// genetic algorithm always reference valid parts from the original
+        /// schedule.
         /// </summary>
-        /// <returns>A new SequenceChromosome.</returns>
+        /// <returns>A new SequenceChromosome initialized with the original part identifiers.</returns>
         public override IChromosome CreateNew()
         {
-            return new SequenceChromosome(Length);
+            return new SequenceChromosome(idByIndex);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Prevent SequenceChromosome.CreateNew from using placeholder IDs
- Maintain original part identifiers when creating new chromosomes to avoid invalid references

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7631371d4832a94bbb7049b7f3322