### PR TITLE
Preserve part identifiers when creating new sequence chromosomes

### DIFF
--- a/Assets/testgenetics/SequenceChromosome.cs
+++ b/Assets/testgenetics/SequenceChromosome.cs
@@ -68,12 +68,17 @@ namespace UnitySimuLean
         }
 
         /// <summary>
-        /// Creates a new instance of the chromosome with the same length.
+        /// Creates a new instance of the chromosome preserving the mapping
+        /// between sequence indexes and part identifiers.
         /// </summary>
-        /// <returns>A new SequenceChromosome.</returns>
+        /// <returns>A new <see cref="SequenceChromosome"/> with a fresh random
+        /// sequence but referencing the same part identifiers.</returns>
         public override IChromosome CreateNew()
         {
-            return new SequenceChromosome(Length);
+            // Use the original list of part identifiers instead of numeric
+            // placeholders to ensure evolved chromosomes can be translated
+            // back into valid schedule references.
+            return new SequenceChromosome(idByIndex);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- ensure `SequenceChromosome.CreateNew` keeps original reference mapping
- document purpose of `CreateNew` and avoid numeric placeholders

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package 'dotnet-sdk-6.0' has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68b7631371d4832a94bbb7049b7f3322