### PR TITLE
Fix schedule loader to keep all items and clarify results CSV

### DIFF
--- a/Assets/UnitySimuLean/ExcelScheduleLoader.cs
+++ b/Assets/UnitySimuLean/ExcelScheduleLoader.cs
@@ -112,7 +112,11 @@ namespace UnitySimuLean
                     double.TryParse(dueDateStr, out double dueDate);
                     int.TryParse(priorityStr, out int priority);
 
-                    attributes[referencia] = new ScheduleEntry
+                    // Use the row "Name" as the unique key so that duplicate
+                    // references are preserved. The original "Referencia" is
+                    // still stored inside the entry for downstream lookups.
+                    var key = name;
+                    attributes[key] = new ScheduleEntry
                     {
                         Time = time,
                         Name = name,
@@ -129,7 +133,7 @@ namespace UnitySimuLean
                 }
             }
 
-            // Order references by time then by priority
+            // Order entries by time then by priority
             var ordered = new List<KeyValuePair<string, ScheduleEntry>>(attributes);
             ordered.Sort((a, b) =>
             {

--- a/Assets/testgenetics/GeneticSequenceTester.cs
+++ b/Assets/testgenetics/GeneticSequenceTester.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Linq;
 using UnityEngine;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -131,11 +132,12 @@ namespace UnitySimuLean
             var csvPath = Path.Combine(logsPath, CsvFileName);
             if (!File.Exists(csvPath))
             {
-                File.WriteAllText(csvPath, "PriorityOrder,DelayCount,InspectionCount\n");
+                File.WriteAllText(csvPath, "PartSequence,PriorityOrder,DelayCount,InspectionCount\n");
             }
 
-            var sequenceValue = string.Join(",", sequence);
-            var line = $"\"{sequenceValue}\",{delayCount},{inspectionCount}\n";
+            var partSequence = string.Join(",", sequence);
+            var priorities = string.Join(",", Enumerable.Range(1, sequence.Length));
+            var line = $"\"{partSequence}\",\"{priorities}\",{delayCount},{inspectionCount}\n";
             File.AppendAllText(csvPath, line);
             Debug.Log($"Results written to {csvPath}");
         }


### PR DESCRIPTION
## Summary
- preserve all schedule rows by keying on Name instead of Referencia
- log part sequence alongside explicit priority order in CSV output

## Testing
- `dotnet build` *(fails: command not found)*
- `python - <<'PY'
import pandas as pd

df = pd.read_excel('Llegada_Chapas.xlsx')
# Simulate old behavior: keyed by Referencia
by_referencia = {row.Referencia: row for _, row in df.iterrows()}
print('entries using Referencia key', len(by_referencia))
# New behavior: keyed by Name
by_name = {row.Name: row for _, row in df.iterrows()}
print('entries using Name key', len(by_name))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b772798fa8832aac72553689ba6634