### PR TITLE
Fix delay counter by preserving item labels

### DIFF
--- a/Assets/SimuLean.Net/SimElements/Combiner.cs
+++ b/Assets/SimuLean.Net/SimElements/Combiner.cs
@@ -302,8 +302,10 @@ namespace SimuLean
             UnityCombiner uc = vElement as UnityCombiner;
             if (uc != null && uc.visualMode == VisualMode.NewItem)
             {
-                // 1. Crear el nuevo ítem combinado usando CreateNewItem().
-                Item newItem = CreateNewItem();
+                // 1. Crear el nuevo ítem combinado usando CreateNewItem()
+                //    copiando las etiquetas del ítem original para preservar
+                //    información como el DueDate.
+                Item newItem = CreateNewItem(process.theItem);
                 GameObject newCombinedItem = newItem.vItem as GameObject;
                 if (newCombinedItem != null)
                 {

--- a/Assets/SimuLean.Net/SimElements/MultiAssembler.cs
+++ b/Assets/SimuLean.Net/SimElements/MultiAssembler.cs
@@ -190,7 +190,6 @@ namespace SimuLean
                 {
                     completedItems++;
                     receivingItems = true;
-                    newItem = CreateNewItem();
 
                     theProcess = idleProccesses.Dequeue();
 
@@ -198,6 +197,12 @@ namespace SimuLean
                     {
                         items = inputs[i].Release(requirements[i]);
 
+                        // Use first input as the source for labels when creating the new item
+                        if (i == 0)
+                        {
+                            Item sourceItem = items.Count > 0 ? items.Peek() : null;
+                            newItem = CreateNewItem(sourceItem);
+                        }
 
                         foreach (Item it in items)
                         {
@@ -237,12 +242,18 @@ namespace SimuLean
             }
         }
 
-        Item CreateNewItem()
+        Item CreateNewItem(Item sourceItem = null)
         {
             Item newItem = new Item(simClock.GetSimulationTime());
             newItem.SetId("type", 1, 1);
 
             newItem.vItem = vElement.GenerateItem(0);
+
+            // Preserve labels such as DueDate from the original item when provided
+            if (sourceItem != null)
+            {
+                newItem.CopyLabelsFrom(sourceItem);
+            }
 
             return newItem;
         }


### PR DESCRIPTION
## Summary
- Ensure combined items carry over labels (e.g., DueDate) when generated by `Combiner`
- Preserve labels on items generated by `MultiAssembler` using the first input as source

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b78298c8a4832aa4789873e559576f