### PR TITLE
Ensure GA metrics retrieved correctly

### DIFF
--- a/Assets/testgenetics/SequenceOptimizer.cs
+++ b/Assets/testgenetics/SequenceOptimizer.cs
@@ -114,8 +114,12 @@ namespace UnitySimuLean
             }
 
             var bestSequence = bestChromosome.GetSequence();
-            var bestFitness = bestChromosome.Fitness ?? 0;
-            var (delayCount, inspectionCount) = fitness.GetMetrics(bestChromosome);
+
+            // Re-evaluate the best chromosome to ensure metrics are available even if
+            // GeneticSharp cloned the chromosome during evolution, which would prevent
+            // the cached metrics from being retrieved correctly.
+            var (bestFitness, delayCount, inspectionCount) =
+                fitness.EvaluateWithMetrics(bestChromosome);
 
             Debug.Log(
                 $"Best sequence found: {string.Join(",", bestSequence)} " +


### PR DESCRIPTION
## Summary
- Recompute best chromosome metrics after GeneticSharp optimization to keep correct delay and inspection counts

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b784085528832aa1fb4117ab434025