### PR TITLE
Ensure positive fitness for roulette selection

### DIFF
--- a/Assets/testgenetics/SequenceFitness.cs
+++ b/Assets/testgenetics/SequenceFitness.cs
@@ -81,10 +81,22 @@ namespace UnitySimuLean
             // Store metrics for later retrieval.
             _metrics[chromosome] = (delayCount, inspectionCount);
 
-            // 4. Compute a fitness score. Any change in inspection count is heavily penalised.
-            double fitness = inspectionCount == _requiredInspectionCount
-                ? -delayCount
-                : double.MinValue;
+            // 4. Compute a fitness score. Genetic algorithms such as GeneticSharp
+            // expect fitness values to be non‑negative when using roulette wheel
+            // selection. Transform the delay count into a positive score and assign
+            // a tiny positive value to sequences that do not match the required
+            // inspection count so the selection operator can still function.
+            double fitness;
+            if (inspectionCount == _requiredInspectionCount)
+            {
+                // Lower delay counts should yield higher fitness values.
+                fitness = 1.0 / (1 + delayCount);
+            }
+            else
+            {
+                // Heavy penalty for sequences that change the inspection count.
+                fitness = 1e-6;
+            }
 
             return (fitness, delayCount, inspectionCount);
         }


### PR DESCRIPTION
## Summary
- Compute non-negative fitness values to support roulette wheel selection in SequenceFitness
- Penalize invalid inspection counts with a tiny positive fitness to avoid GA exceptions

## Testing
- `dotnet --version` *(fails: command not found)*
- `mcs Assets/testgenetics/*.cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b787a0d138832a95d335e5b0478832