### PR TITLE
Ensure GA population size minimum

### DIFF
--- a/Assets/testgenetics/GeneticAlgorithmSettings.cs
+++ b/Assets/testgenetics/GeneticAlgorithmSettings.cs
@@ -15,7 +15,10 @@ namespace UnitySimuLean
         public int generations = 100;
 
         [Tooltip("Population size per generation.")]
-        [Min(1)]
+        // GeneticSharp requires at least two chromosomes per generation.
+        // Enforce a minimum of 2 to prevent runtime errors when configured
+        // through a ScriptableObject.
+        [Min(2)]
         public int populationSize = 50;
 
         [Header("Genetic Operators")]

--- a/Assets/testgenetics/GeneticSequenceTester.cs
+++ b/Assets/testgenetics/GeneticSequenceTester.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using UnityEngine;
 #if UNITY_EDITOR
@@ -86,6 +87,10 @@ namespace UnitySimuLean
             var nParts = settings != null ? settings.numberOfParts : numberOfParts;
             var gens = settings != null ? settings.generations : generations;
             var popSize = settings != null ? settings.populationSize : populationSize;
+            // GeneticSharp requires at least two chromosomes per generation.
+            // Clamp the population size to the minimum allowed value to avoid
+            // runtime exceptions when misconfigured.
+            popSize = Math.Max(2, popSize);
             var selType = settings != null ? settings.selectionType : selectionType;
             var crossType = settings != null ? settings.crossoverType : crossoverType;
             var mutType = settings != null ? settings.mutationType : mutationType;


### PR DESCRIPTION
## Summary
- Prevent misconfigured genetic runs by clamping population size to at least two in the tester
- Enforce minimum population size in GeneticAlgorithmSettings ScriptableObject

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b78a469004832a8296a77f168ea739