### PR TITLE
Handle DueDate-based delays in Genetic Sequence Tester

### DIFF
--- a/Assets/SimuLean.Net/SimElements/Item.cs
+++ b/Assets/SimuLean.Net/SimElements/Item.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using UnityEngine;
 
@@ -140,6 +141,30 @@ namespace SimuLean
             {
                 return attribDouble[label];
             }
+            return null;
+        }
+
+        /// <summary>
+        /// Retrieves the value of a label using a case-insensitive comparison.
+        /// Returns <c>null</c> when the label is not found.
+        /// </summary>
+        /// <param name="label">Label name to search for.</param>
+        /// <returns>The value associated with the label or <c>null</c>.</returns>
+        public double? GetLabelValueIgnoreCase(string label)
+        {
+            if (attribDouble == null || string.IsNullOrEmpty(label))
+            {
+                return null;
+            }
+
+            foreach (var kvp in attribDouble)
+            {
+                if (kvp.Key.Equals(label, StringComparison.OrdinalIgnoreCase))
+                {
+                    return kvp.Value;
+                }
+            }
+
             return null;
         }
 

--- a/Assets/SimuLean.Net/SimElements/Sink.cs
+++ b/Assets/SimuLean.Net/SimElements/Sink.cs
@@ -69,9 +69,9 @@ namespace SimuLean
             double tiempoActual = simClock.GetSimulationTime();
             numberIterms++;
 
-            // Contar inspección si la etiqueta inspeccionOn == 1
-            var labelInspObj = theItem.GetLabelValue("inspeccionOn");
-            if (labelInspObj != null && labelInspObj.Value == 1)
+            // Contar inspección si la etiqueta inspeccionOn >= 1 (insensible a mayúsculas)
+            var labelInspObj = theItem.GetLabelValueIgnoreCase("inspeccionOn");
+            if (labelInspObj.HasValue && labelInspObj.Value >= 1)
             {
                 inspeccionesRealizadas++;
             }

--- a/Assets/SimuLean.Net/SimElements/Sink.cs
+++ b/Assets/SimuLean.Net/SimElements/Sink.cs
@@ -76,30 +76,12 @@ namespace SimuLean
                 inspeccionesRealizadas++;
             }
 
-            // Contar retraso si tiempoActual > Deadline/DueDate (ignorando mayúsculas)
-            double? labelDeadlineObj = theItem.GetLabelValue("Deadline") ?? theItem.GetLabelValue("DueDate");
-            if (labelDeadlineObj == null)
+            // Contar retraso si el ítem tiene un Deadline/DueDate y llega tarde.
+            double? labelDeadlineObj = theItem.GetLabelValueIgnoreCase("Deadline")
+                                     ?? theItem.GetLabelValueIgnoreCase("DueDate");
+            if (labelDeadlineObj.HasValue && tiempoActual > labelDeadlineObj.Value)
             {
-                foreach (KeyValuePair<string, object> kvp in theItem.GetAllLabels())
-                {
-                    if (kvp.Key.Equals("Deadline", StringComparison.OrdinalIgnoreCase) ||
-                        kvp.Key.Equals("DueDate", StringComparison.OrdinalIgnoreCase))
-                    {
-                        if (kvp.Value is double d)
-                        {
-                            labelDeadlineObj = d;
-                            break;
-                        }
-                    }
-                }
-            }
-            if (labelDeadlineObj != null)
-            {
-                double tDeadline = labelDeadlineObj.Value;
-                if (tiempoActual > tDeadline)
-                {
-                    retrasados++;
-                }
+                retrasados++;
             }
 
             vElement.LoadItem(theItem);

--- a/Assets/testgenetics/SequenceFitness.cs
+++ b/Assets/testgenetics/SequenceFitness.cs
@@ -1,7 +1,6 @@
 using System;
 using GeneticSharp.Domain.Chromosomes;
 using GeneticSharp.Domain.Fitnesses;
-using System.Collections.Generic;
 
 namespace UnitySimuLean
 {
@@ -14,8 +13,6 @@ namespace UnitySimuLean
     {
         private readonly ISimulationRunner _runner;
         private readonly int _requiredInspectionCount;
-        private readonly Dictionary<IChromosome, (int delay, int inspections)> _metrics =
-            new Dictionary<IChromosome, (int delay, int inspections)>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SequenceFitness"/> class.
@@ -78,35 +75,12 @@ namespace UnitySimuLean
             int delayCount = _runner.DelayCount;
             int inspectionCount = _runner.InspectionCount;
 
-            // Store metrics for later retrieval.
-            _metrics[chromosome] = (delayCount, inspectionCount);
-
             // 4. Compute a fitness score. Any change in inspection count is heavily penalised.
             double fitness = inspectionCount == _requiredInspectionCount
                 ? -delayCount
                 : double.MinValue;
 
             return (fitness, delayCount, inspectionCount);
-        }
-
-        /// <summary>
-        /// Gets the metrics collected for a previously evaluated chromosome.
-        /// </summary>
-        /// <param name="chromosome">Chromosome whose metrics are requested.</param>
-        /// <returns>The delay count and inspection count associated with the chromosome.</returns>
-        public (int delayCount, int inspectionCount) GetMetrics(IChromosome chromosome)
-        {
-            if (_metrics.TryGetValue(chromosome, out var metrics))
-            {
-                // Remove metrics from previous chromosomes to avoid uncontrolled
-                // growth of the dictionary. Retain only the metrics for the
-                // requested chromosome so they remain available if needed again.
-                _metrics.Clear();
-                _metrics[chromosome] = metrics;
-                return metrics;
-            }
-
-            return (0, 0);
         }
     }
 }

--- a/Assets/testgenetics/SequenceOptimizer.cs
+++ b/Assets/testgenetics/SequenceOptimizer.cs
@@ -105,8 +105,7 @@ namespace UnitySimuLean
             }
 
             var bestSequence = bestChromosome.GetSequence();
-            var bestFitness = bestChromosome.Fitness ?? 0;
-            var (delayCount, inspectionCount) = fitness.GetMetrics(bestChromosome);
+            var (bestFitness, delayCount, inspectionCount) = fitness.EvaluateWithMetrics(bestChromosome);
 
             Debug.Log(
                 $"Best sequence found: {string.Join(",", bestSequence)} " +


### PR DESCRIPTION
## Summary
- add case-insensitive label lookup to items
- count plates as delayed when arrival exceeds Deadline/DueDate in sink

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fe70b6c4832aa6bdf8854c6c5617