### PR TITLE
Adjust fitness to favour inspections and penalize delays

### DIFF
--- a/Assets/testgenetics/SequenceFitness.cs
+++ b/Assets/testgenetics/SequenceFitness.cs
@@ -13,7 +13,8 @@ namespace UnitySimuLean
     public class SequenceFitness : IFitness
     {
         private readonly ISimulationRunner _runner;
-        private readonly int _requiredInspectionCount;
+        private readonly int _delayPenalty;
+        private readonly int _inspectionReward;
         private readonly Dictionary<IChromosome, (int delay, int inspections)> _metrics =
             new Dictionary<IChromosome, (int delay, int inspections)>();
 
@@ -21,15 +22,13 @@ namespace UnitySimuLean
         /// Initializes a new instance of the <see cref="SequenceFitness"/> class.
         /// </summary>
         /// <param name="runner">Simulation runner used to evaluate sequences.</param>
-        /// <param name="requiredInspectionCount">
-        /// Number of inspections that must remain constant across evaluations.
-        /// Any chromosome producing a different value will receive the worst
-        /// possible fitness.
-        /// </param>
-        public SequenceFitness(ISimulationRunner runner, int requiredInspectionCount)
+        /// <param name="delayPenalty">Penalty applied per delay.</param>
+        /// <param name="inspectionReward">Reward applied per inspection.</param>
+        public SequenceFitness(ISimulationRunner runner, int delayPenalty = 100, int inspectionReward = 1)
         {
             _runner = runner ?? throw new ArgumentNullException(nameof(runner));
-            _requiredInspectionCount = requiredInspectionCount;
+            _delayPenalty = delayPenalty;
+            _inspectionReward = inspectionReward;
         }
 
         /// <summary>
@@ -81,10 +80,8 @@ namespace UnitySimuLean
             // Store metrics for later retrieval.
             _metrics[chromosome] = (delayCount, inspectionCount);
 
-            // 4. Compute a fitness score. Any change in inspection count is heavily penalised.
-            double fitness = inspectionCount == _requiredInspectionCount
-                ? -delayCount
-                : double.MinValue;
+            // 4. Compute a fitness score prioritizing minimal delays and maximal inspections.
+            double fitness = (inspectionCount * _inspectionReward) - (delayCount * _delayPenalty);
 
             return (fitness, delayCount, inspectionCount);
         }

--- a/Assets/testgenetics/SequenceOptimizer.cs
+++ b/Assets/testgenetics/SequenceOptimizer.cs
@@ -45,17 +45,7 @@ namespace UnitySimuLean
             // runtime exceptions when a smaller value is provided.
             populationSize = Math.Max(2, populationSize);
 
-            // Run a baseline simulation to determine the required number of inspections.
-            var baselineSequence = new string[numberOfParts];
-            for (int i = 0; i < numberOfParts; i++)
-            {
-                baselineSequence[i] = i.ToString();
-            }
-            runner.Configure(baselineSequence);
-            runner.Run();
-            var requiredInspectionCount = runner.InspectionCount;
-
-            var fitness = new SequenceFitness(runner, requiredInspectionCount);
+            var fitness = new SequenceFitness(runner);
             var chromosome = new SequenceChromosome(numberOfParts);
             var population = new Population(populationSize, populationSize * 2, chromosome);
             ISelection selection;


### PR DESCRIPTION
## Summary
- update SequenceFitness to reward inspections and penalize delays
- simplify SequenceOptimizer to use new fitness without baseline simulation

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68b80b89c8dc832ab9769450143d3dcd