### PR TITLE
Load schedule times from Excel during optimization

### DIFF
--- a/Assets/UnitySimuLean/UnitySimulationRunner.cs
+++ b/Assets/UnitySimuLean/UnitySimulationRunner.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Data;
+using System.IO;
 using SimuLean;
+using ExcelDataReader;
 
 namespace UnitySimuLean
 {
@@ -18,6 +21,15 @@ namespace UnitySimuLean
         private readonly SimClock _clock = new SimClock();
         private ScheduleSource _source;
         private Sink _sink;
+        private List<Dictionary<string, string>> _scheduleRows;
+
+        /// <summary>
+        /// Optional path to an Excel file containing the arrival schedule
+        /// for the sheet metal pieces. When provided the optimizer will
+        /// read <c>tSoldadura</c>, <c>tInspeccion</c> and any due date
+        /// information directly from this file.
+        /// </summary>
+        public string ScheduleFilePath { get; set; }
 
         /// <summary>
         /// Optional visual representation for the initial <see cref="ScheduleSource"/>.
@@ -36,6 +48,53 @@ namespace UnitySimuLean
         private int _delayCount;
         private int _inspectionCount;
 
+        /// <summary>
+        /// Loads the schedule from <see cref="ScheduleFilePath"/> if it has not
+        /// been loaded yet.
+        /// </summary>
+        public void LoadSchedule()
+        {
+            if (_scheduleRows != null)
+            {
+                return;
+            }
+
+            if (string.IsNullOrEmpty(ScheduleFilePath))
+            {
+                throw new InvalidOperationException("ScheduleFilePath must be set before loading the schedule.");
+            }
+
+            System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+            _scheduleRows = new List<Dictionary<string, string>>();
+            using (var stream = File.Open(ScheduleFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (var reader = ExcelReaderFactory.CreateReader(stream))
+            {
+                var result = reader.AsDataSet();
+                DataTable table = result.Tables[0];
+                int colCount = table.Columns.Count;
+                var headers = new string[colCount];
+                for (int i = 0; i < colCount; i++)
+                {
+                    headers[i] = table.Rows[0][i]?.ToString() ?? string.Empty;
+                }
+
+                for (int row = 1; row < table.Rows.Count; row++)
+                {
+                    var dict = new Dictionary<string, string>();
+                    for (int col = 0; col < colCount; col++)
+                    {
+                        dict[headers[col]] = table.Rows[row][col]?.ToString() ?? string.Empty;
+                    }
+                    _scheduleRows.Add(dict);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Total number of parts loaded from the schedule file.
+        /// </summary>
+        public int PartCount => _scheduleRows?.Count ?? 0;
+
         /// <inheritdoc />
         public void Configure(string[] sequence)
         {
@@ -48,30 +107,44 @@ namespace UnitySimuLean
             _clock.Reset();
             Element.GetElements().Clear();
 
-            // Build an in-memory schedule representing the provided sequence.
-            var dataDict = new Dictionary<string, List<string>>
+            // Ensure the schedule rows are loaded from the Excel file.
+            LoadSchedule();
+
+            if (_scheduleRows == null || _scheduleRows.Count == 0)
             {
-                {"Time", new List<string>()},
-                {"Name", new List<string>()},
-                {"Q", new List<string>()},
-                {"type", new List<string>()}
-            };
+                throw new InvalidOperationException("No schedule data loaded.");
+            }
+
+            // Build an in-memory schedule respecting the provided sequence.
+            // Each entry in the sequence corresponds to the index of a row
+            // within the Excel schedule. All columns beyond Time/Name/Q are
+            // preserved as labels so that processing and deadlines are taken
+            // into account.
+            var dataDict = new Dictionary<string, List<string>>();
+            foreach (var key in _scheduleRows[0].Keys)
+            {
+                dataDict[key] = new List<string>();
+            }
 
             foreach (var partId in sequence)
             {
-                // For simplicity all arrivals occur at time 0 with quantity 1 and
-                // a generic name. The important piece of information is the
-                // 'type' which represents the part identifier.
-                dataDict["Time"].Add("0");
-                dataDict["Name"].Add("Part");
-                dataDict["Q"].Add("1");
-                dataDict["type"].Add(partId);
+                if (!int.TryParse(partId, out int rowIndex) ||
+                    rowIndex < 0 || rowIndex >= _scheduleRows.Count)
+                {
+                    throw new ArgumentException($"Invalid part index: {partId}", nameof(sequence));
+                }
+
+                var row = _scheduleRows[rowIndex];
+                foreach (var kv in row)
+                {
+                    dataDict[kv.Key].Add(kv.Value);
+                }
             }
 
             // Rebuild source and sink with the new schedule. Attach provided
             // visual elements when available so that items can be observed in
             // the Unity scene. Fall back to headless execution otherwise.
-            _source = new ScheduleSource("Source", _clock, null, dataDict, null, null)
+            _source = new ScheduleSource("Source", _clock, null, dataDict, null, null, autoSort: false)
             {
                 vElement = SourceView ?? new NullVElement()
             };

--- a/Assets/UnitySimuLean/UnitySimulationRunnerBehaviour.cs
+++ b/Assets/UnitySimuLean/UnitySimulationRunnerBehaviour.cs
@@ -13,6 +13,7 @@ namespace UnitySimuLean
         {
             runner.SourceView = source;
             runner.SinkView = sink;
+            runner.ScheduleFilePath = source != null ? source.fileName : null;
             runner.Configure(sequence);
         }
 
@@ -21,5 +22,9 @@ namespace UnitySimuLean
         public int DelayCount => runner.DelayCount;
 
         public int InspectionCount => runner.InspectionCount;
+
+        public void LoadSchedule() => runner.LoadSchedule();
+
+        public int PartCount => runner.PartCount;
     }
 }

--- a/Assets/testgenetics/GeneticSequenceTester.cs
+++ b/Assets/testgenetics/GeneticSequenceTester.cs
@@ -83,6 +83,13 @@ namespace UnitySimuLean
                 return;
             }
 
+            if (simulationRunner is UnitySimulationRunnerBehaviour usb)
+            {
+                // Load schedule so the number of parts can be derived from the Excel file.
+                usb.LoadSchedule();
+                numberOfParts = usb.PartCount;
+            }
+
             var nParts = settings != null ? settings.numberOfParts : numberOfParts;
             var gens = settings != null ? settings.generations : generations;
             var popSize = settings != null ? settings.populationSize : populationSize;


### PR DESCRIPTION
## Summary
- Load sheet arrival schedule from Excel in `UnitySimulationRunner` so tSoldadura, tInspeccion and deadlines are preserved during genetic optimization
- Expose schedule loading through `UnitySimulationRunnerBehaviour` and fetch part count from Excel in the tester

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package dotnet-sdk-8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b8121714e4832aa45c19c67227c53c