### PR TITLE
Use arrival sheet data when optimizing part sequence

### DIFF
--- a/Assets/UnitySimuLean/UnitySimulationRunner.cs
+++ b/Assets/UnitySimuLean/UnitySimulationRunner.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using ExcelDataReader;
 using SimuLean;
 
 namespace UnitySimuLean
@@ -19,6 +22,18 @@ namespace UnitySimuLean
         private ScheduleSource _source;
         private Sink _sink;
 
+        private class PlateInfo
+        {
+            public double ArrivalTime;
+            public double WeldTime;
+            public double InspectionTime;
+            public int InspectionOn;
+            public double DueDate;
+        }
+
+        private Dictionary<string, PlateInfo> _plateData;
+        private const string ArrivalFile = "Llegada_Chapas.xlsx";
+
         /// <summary>
         /// Optional visual representation for the initial <see cref="ScheduleSource"/>.
         /// When set, generated items will use this <see cref="VElement"/> instead of a
@@ -36,6 +51,72 @@ namespace UnitySimuLean
         private int _delayCount;
         private int _inspectionCount;
 
+        private void LoadPlateData()
+        {
+            if (_plateData != null)
+            {
+                return;
+            }
+
+            _plateData = new Dictionary<string, PlateInfo>();
+            try
+            {
+                System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+                using var stream = File.Open(ArrivalFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                using var reader = ExcelReaderFactory.CreateReader(stream);
+                var result = reader.AsDataSet();
+                var table = result.Tables[0];
+                int cols = table.Columns.Count;
+                string[] headers = new string[cols];
+                for (int c = 0; c < cols; c++)
+                {
+                    headers[c] = table.Rows[0][c]?.ToString() ?? string.Empty;
+                }
+
+                for (int r = 1; r < table.Rows.Count; r++)
+                {
+                    var rowDict = new Dictionary<string, string>();
+                    for (int c = 0; c < cols; c++)
+                    {
+                        rowDict[headers[c]] = table.Rows[r][c]?.ToString() ?? string.Empty;
+                    }
+
+                    if (!rowDict.TryGetValue("Referencia", out var refId) || string.IsNullOrWhiteSpace(refId))
+                    {
+                        continue;
+                    }
+
+                    var info = new PlateInfo();
+                    if (rowDict.TryGetValue("Time", out var tStr))
+                    {
+                        double.TryParse(tStr, NumberStyles.Any, CultureInfo.InvariantCulture, out info.ArrivalTime);
+                    }
+                    if (rowDict.TryGetValue("tSoldadura", out var wStr))
+                    {
+                        double.TryParse(wStr, NumberStyles.Any, CultureInfo.InvariantCulture, out info.WeldTime);
+                    }
+                    if (rowDict.TryGetValue("tInspeccion", out var iStr))
+                    {
+                        double.TryParse(iStr, NumberStyles.Any, CultureInfo.InvariantCulture, out info.InspectionTime);
+                    }
+                    if (rowDict.TryGetValue("inspeccionOn", out var onStr))
+                    {
+                        int.TryParse(onStr, NumberStyles.Any, CultureInfo.InvariantCulture, out info.InspectionOn);
+                    }
+                    if (rowDict.TryGetValue("DueDate", out var dStr))
+                    {
+                        double.TryParse(dStr, NumberStyles.Any, CultureInfo.InvariantCulture, out info.DueDate);
+                    }
+
+                    _plateData[refId] = info;
+                }
+            }
+            catch (IOException)
+            {
+                // If the file cannot be read, leave dictionary empty and rely on defaults.
+            }
+        }
+
         /// <inheritdoc />
         public void Configure(string[] sequence)
         {
@@ -48,24 +129,36 @@ namespace UnitySimuLean
             _clock.Reset();
             Element.GetElements().Clear();
 
+            LoadPlateData();
+
             // Build an in-memory schedule representing the provided sequence.
             var dataDict = new Dictionary<string, List<string>>
             {
                 {"Time", new List<string>()},
                 {"Name", new List<string>()},
                 {"Q", new List<string>()},
-                {"type", new List<string>()}
+                {"type", new List<string>()},
+                {"tSoldadura", new List<string>()},
+                {"tInspeccion", new List<string>()},
+                {"inspeccionOn", new List<string>()},
+                {"DueDate", new List<string>()}
             };
 
             foreach (var partId in sequence)
             {
-                // For simplicity all arrivals occur at time 0 with quantity 1 and
-                // a generic name. The important piece of information is the
-                // 'type' which represents the part identifier.
-                dataDict["Time"].Add("0");
+                if (!_plateData.TryGetValue(partId, out var info))
+                {
+                    info = new PlateInfo();
+                }
+
+                dataDict["Time"].Add(info.ArrivalTime.ToString(CultureInfo.InvariantCulture));
                 dataDict["Name"].Add("Part");
                 dataDict["Q"].Add("1");
                 dataDict["type"].Add(partId);
+                dataDict["tSoldadura"].Add(info.WeldTime.ToString(CultureInfo.InvariantCulture));
+                dataDict["tInspeccion"].Add(info.InspectionTime.ToString(CultureInfo.InvariantCulture));
+                dataDict["inspeccionOn"].Add(info.InspectionOn.ToString(CultureInfo.InvariantCulture));
+                dataDict["DueDate"].Add(info.DueDate.ToString(CultureInfo.InvariantCulture));
             }
 
             // Rebuild source and sink with the new schedule. Attach provided


### PR DESCRIPTION
## Summary
- load plate arrival information from Llegada_Chapas.xlsx to build simulation schedule
- include welding/inspection durations and deadlines for delay metrics

## Testing
- ❌ `dotnet build` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b8121714e4832aa45c19c67227c53c