### PR TITLE
Implement genetic algorithm chapa optimizer with CSV export

### DIFF
--- a/Assets/Scripts/Editor/ChapasGAControllerEditor.cs
+++ b/Assets/Scripts/Editor/ChapasGAControllerEditor.cs
@@ -1,0 +1,34 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+using ChapasGA.Mono;
+
+namespace ChapasGA.Editor
+{
+    [CustomEditor(typeof(ChapasGAController))]
+    public class ChapasGAControllerEditor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            DrawDefaultInspector();
+            var controller = (ChapasGAController)target;
+            if (GUILayout.Button("Cargar Excel"))
+            {
+                controller.LoadExcel();
+            }
+            if (GUILayout.Button("Ejecutar GA"))
+            {
+                controller.RunGA();
+            }
+            if (GUILayout.Button("Exportar CSV"))
+            {
+                controller.ExportCSV();
+            }
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("BestFitness", controller.BestFitness.ToString("F2"));
+            EditorGUILayout.LabelField("Inspections", controller.TotalInspections.ToString());
+            EditorGUILayout.LabelField("Delays", controller.TotalDelays.ToString());
+        }
+    }
+}
+#endif

--- a/Assets/Scripts/GA/ChapaChromosome.cs
+++ b/Assets/Scripts/GA/ChapaChromosome.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Linq;
+using GeneticSharp.Domain.Chromosomes;
+using GeneticSharp.Infrastructure.Framework.Threading;
+
+namespace ChapasGA.GA
+{
+    public class ChapaChromosome : ChromosomeBase
+    {
+        private readonly int _jobs;
+        private readonly bool[] _inspectionRequired;
+        private int[] _order;
+        private bool[] _inspect;
+
+        public ChapaChromosome(int jobs, bool[] inspectionRequired) : base(2 * jobs)
+        {
+            _jobs = jobs;
+            _inspectionRequired = inspectionRequired;
+            InitializeRandom();
+        }
+
+        private ChapaChromosome(ChapaChromosome source) : base(source.Length)
+        {
+            _jobs = source._jobs;
+            _inspectionRequired = source._inspectionRequired;
+            _order = source._order.ToArray();
+            _inspect = source._inspect.ToArray();
+            SyncGenes();
+        }
+
+        public int[] Order
+        {
+            get => _order;
+            set { _order = value; SyncGenes(); }
+        }
+
+        public bool[] Inspect
+        {
+            get => _inspect;
+            set { _inspect = value; SyncGenes(); }
+        }
+
+        public bool[] InspectionRequired => _inspectionRequired;
+
+        private void InitializeRandom()
+        {
+            _order = GeneticSharp.Domain.Randomizations.RandomizationProvider.Current.GetPermutation(_jobs);
+            _inspect = new bool[_jobs];
+            for (int i = 0; i < _jobs; i++)
+            {
+                _inspect[i] = _inspectionRequired[i] || GeneticSharp.Domain.Randomizations.RandomizationProvider.Current.GetDouble() > 0.5;
+            }
+            SyncGenes();
+        }
+
+        private void SyncGenes()
+        {
+            for (int i = 0; i < _jobs; i++)
+            {
+                ReplaceGene(i, new Gene(_order[i]));
+                ReplaceGene(_jobs + i, new Gene(_inspect[i] ? 1 : 0));
+            }
+        }
+
+        public void Repair()
+        {
+            for (int i = 0; i < _jobs; i++)
+            {
+                if (_inspectionRequired[i])
+                    _inspect[i] = true;
+            }
+            SyncGenes();
+        }
+
+        public override Gene GenerateGene(int geneIndex)
+        {
+            if (geneIndex < _jobs)
+                return new Gene(_order[geneIndex]);
+            return new Gene(_inspect[geneIndex - _jobs] ? 1 : 0);
+        }
+
+        public override IChromosome CreateNew()
+        {
+            return new ChapaChromosome(_jobs, _inspectionRequired);
+        }
+
+        public override IChromosome Clone()
+        {
+            return new ChapaChromosome(this);
+        }
+
+        public static ChapaChromosome CreateFromData(System.Collections.Generic.IList<Models.Chapa> chapas)
+        {
+            var required = chapas.Select(c => c.InspeccionOn).ToArray();
+            var c = new ChapaChromosome(chapas.Count, required);
+            c._order = Enumerable.Range(0, chapas.Count).ToArray();
+            c._inspect = chapas.Select(ch => ch.InspeccionOn).ToArray();
+            c.SyncGenes();
+            return c;
+        }
+    }
+}

--- a/Assets/Scripts/GA/ChapaCrossover.cs
+++ b/Assets/Scripts/GA/ChapaCrossover.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using GeneticSharp.Domain.Chromosomes;
+using GeneticSharp.Domain.Crossovers;
+using GeneticSharp.Domain.Randomizations;
+
+namespace ChapasGA.GA
+{
+    public class ChapaCrossover : ICrossover
+    {
+        public int ParentsNumber => 2;
+        public int ChildrenNumber => 2;
+        public bool IsOrdered => true;
+
+        public IList<IChromosome> Cross(IList<IChromosome> parents)
+        {
+            var p1 = (ChapaChromosome)parents[0].Clone();
+            var p2 = (ChapaChromosome)parents[1].Clone();
+
+            int[] child1Order = Ordered(p1.Order, p2.Order);
+            int[] child2Order = Ordered(p2.Order, p1.Order);
+            bool[] child1Inspect = Uniform(p1.Inspect, p2.Inspect);
+            bool[] child2Inspect = Uniform(p2.Inspect, p1.Inspect);
+
+            var c1 = new ChapaChromosome(p1.Order.Length, p1.InspectionRequired)
+            {
+                Order = child1Order,
+                Inspect = child1Inspect
+            };
+            var c2 = new ChapaChromosome(p1.Order.Length, p1.InspectionRequired)
+            {
+                Order = child2Order,
+                Inspect = child2Inspect
+            };
+            c1.Repair();
+            c2.Repair();
+            return new List<IChromosome> { c1, c2 };
+        }
+
+        private int[] Ordered(int[] a, int[] b)
+        {
+            int n = a.Length;
+            int cut1 = RandomizationProvider.Current.GetInt(0, n);
+            int cut2 = RandomizationProvider.Current.GetInt(0, n);
+            if (cut1 > cut2)
+            {
+                var t = cut1; cut1 = cut2; cut2 = t;
+            }
+            var child = new int[n];
+            for (int i = 0; i < n; i++) child[i] = -1;
+            for (int i = cut1; i <= cut2; i++) child[i] = a[i];
+            int current = (cut2 + 1) % n;
+            for (int i = 0; i < n; i++)
+            {
+                int gene = b[(cut2 + 1 + i) % n];
+                if (System.Array.IndexOf(child, gene) == -1)
+                {
+                    child[current] = gene;
+                    current = (current + 1) % n;
+                }
+            }
+            return child;
+        }
+
+        private bool[] Uniform(bool[] a, bool[] b)
+        {
+            int n = a.Length;
+            var child = new bool[n];
+            for (int i = 0; i < n; i++)
+            {
+                child[i] = RandomizationProvider.Current.GetDouble() < 0.5 ? a[i] : b[i];
+            }
+            return child;
+        }
+    }
+}

--- a/Assets/Scripts/GA/ChapaFitness.cs
+++ b/Assets/Scripts/GA/ChapaFitness.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.Linq;
+using GeneticSharp.Domain.Chromosomes;
+using GeneticSharp.Domain.Fitnesses;
+using ChapasGA.Models;
+
+namespace ChapasGA.GA
+{
+    public class FitnessResult
+    {
+        public double Fitness;
+        public List<double> CompletionTimes;
+        public int TotalInspections;
+        public int TotalDelays;
+    }
+
+    public class ChapaFitness : IFitness
+    {
+        private readonly IList<Chapa> _chapas;
+
+        public ChapaFitness(IList<Chapa> chapas)
+        {
+            _chapas = chapas;
+        }
+
+        public double Evaluate(IChromosome chromosome)
+        {
+            var res = EvaluateWithStats((ChapaChromosome)chromosome);
+            return res.Fitness;
+        }
+
+        public FitnessResult EvaluateWithStats(ChapaChromosome chromosome)
+        {
+            var order = chromosome.Order;
+            var inspect = chromosome.Inspect;
+            double time = 0;
+            int inspections = 0;
+            int delays = 0;
+            var completion = new List<double>(order.Length);
+
+            for (int i = 0; i < order.Length; i++)
+            {
+                var chapa = _chapas[order[i]];
+                double proc = chapa.TSoldadura + (inspect[i] ? chapa.TInspeccion : 0);
+                time += proc;
+                completion.Add(time);
+                if (inspect[i]) inspections++;
+                if (time > chapa.DueDate) delays++;
+            }
+
+            return new FitnessResult
+            {
+                Fitness = inspections - delays * 100,
+                CompletionTimes = completion,
+                TotalInspections = inspections,
+                TotalDelays = delays
+            };
+        }
+    }
+}

--- a/Assets/Scripts/GA/ChapaGARunner.cs
+++ b/Assets/Scripts/GA/ChapaGARunner.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using GeneticSharp.Domain.Chromosomes;
+using GeneticSharp.Domain.Populations;
+using GeneticSharp.Domain.Selections;
+using GeneticSharp.Domain.Terminations;
+using GeneticSharp.Domain;
+using UnityEngine;
+using ChapasGA.Models;
+
+namespace ChapasGA.GA
+{
+    public class GARunResult
+    {
+        public double BestFitness;
+        public int[] Order;
+        public bool[] Inspect;
+        public List<double> CompletionTimes;
+        public int TotalInspections;
+        public int TotalDelays;
+    }
+
+    public class ChapaGARunner
+    {
+        private readonly IList<Chapa> _chapas;
+
+        public ChapaGARunner(IList<Chapa> chapas)
+        {
+            _chapas = chapas;
+        }
+
+        public GARunResult Run(int populationSize, int generations, float crossoverProb, float mutationProb, bool log)
+        {
+            var required = new bool[_chapas.Count];
+            for (int i = 0; i < _chapas.Count; i++) required[i] = _chapas[i].InspeccionOn;
+            var chromosome = new ChapaChromosome(_chapas.Count, required);
+            var population = new Population(populationSize, populationSize, chromosome);
+            var fitness = new ChapaFitness(_chapas);
+            var selection = new TournamentSelection();
+            var crossover = new ChapaCrossover();
+            var mutation = new ChapaMutation();
+            var ga = new GeneticAlgorithm(population, fitness, selection, crossover, mutation)
+            {
+                CrossoverProbability = crossoverProb,
+                MutationProbability = mutationProb,
+                Reinsertion = new GeneticSharp.Domain.Reinsertions.ElitistReinsertion()
+            };
+            ga.Termination = new GenerationNumberTermination(generations);
+            ga.TaskExecutor = new TplTaskExecutor();
+            if (log)
+            {
+                ga.GenerationRan += (s, e) =>
+                {
+                    Debug.Log($"Generation {ga.GenerationsNumber} - Fitness {ga.BestChromosome.Fitness}");
+                };
+            }
+            ga.Start();
+            var best = (ChapaChromosome)ga.BestChromosome;
+            var eval = fitness.EvaluateWithStats(best);
+            return new GARunResult
+            {
+                BestFitness = eval.Fitness,
+                Order = best.Order,
+                Inspect = best.Inspect,
+                CompletionTimes = eval.CompletionTimes,
+                TotalInspections = eval.TotalInspections,
+                TotalDelays = eval.TotalDelays
+            };
+        }
+    }
+}

--- a/Assets/Scripts/GA/ChapaMutation.cs
+++ b/Assets/Scripts/GA/ChapaMutation.cs
@@ -1,0 +1,34 @@
+using GeneticSharp.Domain.Chromosomes;
+using GeneticSharp.Domain.Mutations;
+using GeneticSharp.Domain.Randomizations;
+
+namespace ChapasGA.GA
+{
+    public class ChapaMutation : IMutation
+    {
+        public bool IsOrdered => true;
+
+        public void Mutate(IChromosome chromosome, float probability)
+        {
+            Mutate(chromosome);
+        }
+
+        public void Mutate(IChromosome chromosome)
+        {
+            var c = (ChapaChromosome)chromosome;
+            int n = c.Order.Length;
+            int i1 = RandomizationProvider.Current.GetInt(0, n);
+            int i2 = RandomizationProvider.Current.GetInt(0, n);
+            var tmp = c.Order[i1];
+            c.Order[i1] = c.Order[i2];
+            c.Order[i2] = tmp;
+
+            int bit = RandomizationProvider.Current.GetInt(0, n);
+            if (!c.InspectionRequired[bit])
+            {
+                c.Inspect[bit] = !c.Inspect[bit];
+            }
+            c.Repair();
+        }
+    }
+}

--- a/Assets/Scripts/IO/CsvResultWriter.cs
+++ b/Assets/Scripts/IO/CsvResultWriter.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.IO;
+using ChapasGA.Models;
+
+namespace ChapasGA.IO
+{
+    public class CsvResultWriter
+    {
+        public void Write(string path, IList<Chapa> chapas, int[] order, bool[] inspect, IList<double> completion, int totalInspections, int totalDelays)
+        {
+            using (var sw = new StreamWriter(path, false))
+            {
+                sw.WriteLine("OrderIndex;Name;DoInspect;CompletionTime;DueDate;IsLate");
+                for (int i = 0; i < order.Length; i++)
+                {
+                    var c = chapas[order[i]];
+                    bool late = completion[i] > c.DueDate;
+                    sw.WriteLine($"{i};{c.Name};{(inspect[i] ? 1 : 0)};{completion[i]};{c.DueDate};{(late ? 1 : 0)}");
+                }
+                sw.WriteLine($"TotalInspections;{totalInspections}");
+                sw.WriteLine($"TotalDelays;{totalDelays}");
+            }
+        }
+    }
+}

--- a/Assets/Scripts/IO/ExcelChapaLoader.cs
+++ b/Assets/Scripts/IO/ExcelChapaLoader.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.IO;
+using NPOI.SS.UserModel;
+using NPOI.XSSF.UserModel;
+using UnityEngine;
+using ChapasGA.Models;
+
+namespace ChapasGA.IO
+{
+    public class ExcelChapaLoader
+    {
+        public List<Chapa> LoadFromStreamingAssets(string fileName)
+        {
+            var path = Path.Combine(Application.streamingAssetsPath, fileName);
+            var chapas = new List<Chapa>();
+            if (!File.Exists(path))
+            {
+                Debug.LogError($"Excel file not found at {path}");
+                return chapas;
+            }
+
+            using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read))
+            {
+                IWorkbook workbook = new XSSFWorkbook(fs);
+                ISheet sheet = workbook.GetSheetAt(0);
+                for (int i = 1; i <= sheet.LastRowNum; i++)
+                {
+                    var row = sheet.GetRow(i);
+                    if (row == null) continue;
+                    string name = row.GetCell(1)?.ToString();
+                    double tSold = row.GetCell(5)?.NumericCellValue ?? 0;
+                    double tInsp = row.GetCell(6)?.NumericCellValue ?? 0;
+                    bool inspOn = (row.GetCell(7)?.NumericCellValue ?? 0) > 0;
+                    double dueDate = row.GetCell(8)?.NumericCellValue ?? 0;
+                    if (string.IsNullOrEmpty(name)) continue;
+                    chapas.Add(new Chapa
+                    {
+                        Name = name,
+                        TSoldadura = tSold,
+                        TInspeccion = tInsp,
+                        InspeccionOn = inspOn,
+                        DueDate = dueDate
+                    });
+                }
+            }
+            return chapas;
+        }
+    }
+}

--- a/Assets/Scripts/Models/Chapa.cs
+++ b/Assets/Scripts/Models/Chapa.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace ChapasGA.Models
+{
+    [Serializable]
+    public class Chapa
+    {
+        public string Name;
+        public double TSoldadura;
+        public double TInspeccion;
+        public bool InspeccionOn;
+        public double DueDate;
+    }
+}

--- a/Assets/Scripts/Mono/ChapasGAController.cs
+++ b/Assets/Scripts/Mono/ChapasGAController.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+using ChapasGA.Models;
+using ChapasGA.IO;
+using ChapasGA.GA;
+
+namespace ChapasGA.Mono
+{
+    public class ChapasGAController : MonoBehaviour
+    {
+        [SerializeField] private string excelFileName = "Llegada_Chapas.xlsx";
+        [SerializeField] private int populationSize = 100;
+        [SerializeField] private int generations = 500;
+        [SerializeField] private float crossoverProb = 0.9f;
+        [SerializeField] private float mutationProb = 0.15f;
+        [SerializeField] private bool logToConsole = false;
+        [SerializeField] private bool dryRun = false;
+
+        private List<Chapa> _chapas;
+        private GARunResult _result;
+
+        public double BestFitness => _result?.BestFitness ?? 0;
+        public int TotalInspections => _result?.TotalInspections ?? 0;
+        public int TotalDelays => _result?.TotalDelays ?? 0;
+
+        public void LoadExcel()
+        {
+            var loader = new ExcelChapaLoader();
+            _chapas = loader.LoadFromStreamingAssets(excelFileName);
+            if (logToConsole) Debug.Log($"Loaded {_chapas.Count} chapas.");
+            if (dryRun)
+            {
+                var chrom = ChapaChromosome.CreateFromData(_chapas);
+                var fitness = new ChapaFitness(_chapas);
+                var eval = fitness.EvaluateWithStats(chrom);
+                _result = new GARunResult
+                {
+                    BestFitness = eval.Fitness,
+                    Order = chrom.Order,
+                    Inspect = chrom.Inspect,
+                    CompletionTimes = eval.CompletionTimes,
+                    TotalInspections = eval.TotalInspections,
+                    TotalDelays = eval.TotalDelays
+                };
+                if (logToConsole)
+                {
+                    Debug.Log($"DryRun -> Fitness: {_result.BestFitness}, Inspections: {_result.TotalInspections}, Delays: {_result.TotalDelays}");
+                }
+            }
+        }
+
+        public void RunGA()
+        {
+            if (_chapas == null || _chapas.Count == 0)
+            {
+                Debug.LogWarning("No chapas loaded.");
+                return;
+            }
+            if (dryRun)
+            {
+                Debug.LogWarning("DryRun active; GA not executed.");
+                return;
+            }
+            var runner = new ChapaGARunner(_chapas);
+            _result = runner.Run(populationSize, generations, crossoverProb, mutationProb, logToConsole);
+            if (logToConsole)
+            {
+                Debug.Log($"BestFitness: {_result.BestFitness}, Inspections: {_result.TotalInspections}, Delays: {_result.TotalDelays}");
+            }
+        }
+
+        public void ExportCSV()
+        {
+            if (_result == null)
+            {
+                Debug.LogWarning("No result to export.");
+                return;
+            }
+            string path = Path.Combine(Application.persistentDataPath, "resultado_optimizacion.csv");
+            var writer = new CsvResultWriter();
+            writer.Write(path, _chapas, _result.Order, _result.Inspect, _result.CompletionTimes, _result.TotalInspections, _result.TotalDelays);
+            if (logToConsole)
+            {
+                Debug.Log($"CSV exported to {path}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add model and IO utilities for chapas, including Excel loading and CSV writing
- Implement genetic algorithm with custom chromosome, crossover, mutation, and fitness logic for chapa sequencing
- Provide MonoBehaviour and editor scripts to run GA from Unity inspector and export results

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b8267a15e4832a98c0c0c2c0079bfb