### PR TITLE
Tune GA parameters and input checks for Chapas optimizer

### DIFF
--- a/Assets/GA/ChapaChromosome.cs
+++ b/Assets/GA/ChapaChromosome.cs
@@ -8,20 +8,22 @@ namespace ChapasGA.GA
     public class ChapaChromosome : ChromosomeBase
     {
         private readonly int[] _mandatory;
+        private readonly double _inspectProbability;
         public int LengthPerPart { get; }
 
-        public ChapaChromosome(int length, int[] mandatory)
+        public ChapaChromosome(int length, int[] mandatory, double inspectProbability = 0.5)
             : base(length * 2)
         {
             LengthPerPart = length;
             _mandatory = mandatory;
+            _inspectProbability = inspectProbability;
             CreateGenes();
             Repair();
         }
 
         public override IChromosome CreateNew()
         {
-            return new ChapaChromosome(LengthPerPart, _mandatory);
+            return new ChapaChromosome(LengthPerPart, _mandatory, _inspectProbability);
         }
 
         public override Gene GenerateGene(int geneIndex)
@@ -32,7 +34,11 @@ namespace ChapasGA.GA
                 return new Gene(rnd.GetInt(0, LengthPerPart));
             }
             var idx = geneIndex - LengthPerPart;
-            return new Gene(_mandatory[idx] == 1 ? 1 : rnd.GetInt(0, 2));
+            if (_mandatory[idx] == 1)
+            {
+                return new Gene(1);
+            }
+            return new Gene(rnd.GetDouble() < _inspectProbability ? 1 : 0);
         }
 
         public int[] GetOrder()

--- a/Assets/GA/ChapaCrossover.cs
+++ b/Assets/GA/ChapaCrossover.cs
@@ -66,12 +66,13 @@ namespace ChapasGA.GA
                 child2.ReplaceGene(i, new Gene(c2[i]));
             }
 
-            // Uniform crossover for bits
+            // One-point crossover for inspection bits
             var b1 = p1.GetInspectionBits();
             var b2 = p2.GetInspectionBits();
+            int bitPoint = rnd.GetInt(0, size);
             for (int i = 0; i < size; i++)
             {
-                if (rnd.GetDouble() < 0.5)
+                if (i < bitPoint)
                 {
                     child1.ReplaceGene(size + i, new Gene(b1[i]));
                     child2.ReplaceGene(size + i, new Gene(b2[i]));

--- a/Assets/GA/ChapaGARunner.cs
+++ b/Assets/GA/ChapaGARunner.cs
@@ -4,6 +4,7 @@ using ChapasGA.Models;
 using GeneticSharp.Domain;
 using GeneticSharp.Domain.Populations;
 using GeneticSharp.Domain.Selections;
+using GeneticSharp.Domain.Reinsertions;
 using GeneticSharp.Domain.Terminations;
 
 namespace ChapasGA.GA
@@ -21,17 +22,21 @@ namespace ChapasGA.GA
         {
             int n = chapas.Count;
             var mandatory = chapas.Select(c => c.inspeccionOn).ToArray();
-            var chromosome = new ChapaChromosome(n, mandatory);
+            double baseTime = chapas.Sum(c => c.tSoldadura + (c.inspeccionOn == 1 ? c.tInspeccion : 0));
+            double inspectProb = baseTime >= 0.9 * 21600 ? 0.1 : 0.5;
+            var chromosome = new ChapaChromosome(n, mandatory, inspectProb);
             var fitness = new ChapaFitness(chapas);
             var population = new Population(populationSize, populationSize, chromosome);
-            var selection = new TournamentSelection();
+            var selection = new TournamentSelection(3);
             var crossover = new ChapaCrossover();
             var mutation = new ChapaMutation();
+            var termination = new OrTermination(new GenerationNumberTermination(generations), new FitnessStagnationTermination(100));
             var ga = new GeneticAlgorithm(population, fitness, selection, crossover, mutation)
             {
                 CrossoverProbability = crossoverProb,
                 MutationProbability = mutationProb,
-                Termination = new GenerationNumberTermination(generations)
+                Reinsertion = new ElitistReinsertion(),
+                Termination = termination
             };
 
             ga.Start();

--- a/Assets/IO/ExcelChapaLoader.cs
+++ b/Assets/IO/ExcelChapaLoader.cs
@@ -10,7 +10,8 @@ namespace ChapasGA.IO
 {
     public class ExcelChapaLoader
     {
-        private static readonly string[] RequiredHeaders = { "Name", "tSoldadura", "tInspeccion", "inspeccionOn", "DueDate" };
+        private static readonly string[] RequiredHeaders = { "Name", "tSoldadura", "inspeccionOn", "DueDate" };
+        private const string InspectionHeader = "tInspeccion";
 
         public List<Chapa> LoadFromStreamingAssets(string excelFileName)
         {
@@ -44,13 +45,29 @@ namespace ChapasGA.IO
 
             foreach (DataRow row in table.Rows)
             {
+                double tSold = Math.Max(0, Convert.ToDouble(row["tSoldadura"]));
+                double tIns = table.Columns.Contains(InspectionHeader) && row[InspectionHeader] != DBNull.Value
+                    ? Math.Max(0, Convert.ToDouble(row[InspectionHeader]))
+                    : 0;
+                int insOn = Convert.ToInt32(row["inspeccionOn"]);
+                object dueObj = table.Columns.Contains("DueDate") ? row["DueDate"] : null;
+                double due = 21600;
+                if (dueObj != null && dueObj != DBNull.Value)
+                {
+                    double parsedDue = Convert.ToDouble(dueObj);
+                    if (parsedDue > 0)
+                    {
+                        due = parsedDue;
+                    }
+                }
+
                 var chapa = new Chapa
                 {
                     Name = row["Name"].ToString(),
-                    tSoldadura = Convert.ToDouble(row["tSoldadura"]),
-                    tInspeccion = Convert.ToDouble(row["tInspeccion"]),
-                    inspeccionOn = Convert.ToInt32(row["inspeccionOn"]),
-                    DueDate = Convert.ToDouble(row["DueDate"])
+                    tSoldadura = tSold,
+                    tInspeccion = tIns,
+                    inspeccionOn = insOn,
+                    DueDate = due
                 };
                 result.Add(chapa);
             }

--- a/Assets/Mono/ChapasGAController.cs
+++ b/Assets/Mono/ChapasGAController.cs
@@ -11,9 +11,9 @@ namespace ChapasGA.Mono
     public class ChapasGAController : MonoBehaviour
     {
         [SerializeField] private string excelFileName = "Llegada_Chapas.xlsx";
-        [SerializeField] private int populationSize = 100;
-        [SerializeField] private int generations = 500;
-        [SerializeField] private float crossoverProb = 0.9f;
+        [SerializeField] private int populationSize = 200;
+        [SerializeField] private int generations = 700;
+        [SerializeField] private float crossoverProb = 0.85f;
         [SerializeField] private float mutationProb = 0.15f;
         [SerializeField] private bool dryRun = false;
         [SerializeField] private bool logToConsole = false;
@@ -51,7 +51,9 @@ namespace ChapasGA.Mono
             {
                 int n = _chapas.Count;
                 var mandatory = _chapas.Select(c => c.inspeccionOn).ToArray();
-                var chromo = new ChapaChromosome(n, mandatory);
+                double baseTime = _chapas.Sum(c => c.tSoldadura + (c.inspeccionOn == 1 ? c.tInspeccion : 0));
+                double inspectProb = baseTime >= 0.9 * 21600 ? 0.1 : 0.5;
+                var chromo = new ChapaChromosome(n, mandatory, inspectProb);
                 for (int i = 0; i < n; i++)
                 {
                     chromo.ReplaceGene(i, new Gene(i));
@@ -68,7 +70,11 @@ namespace ChapasGA.Mono
             }
             else
             {
-                _runner.RunGA(_chapas, populationSize, generations, crossoverProb, mutationProb);
+                int pop = Mathf.Clamp(populationSize, 150, 300);
+                int gens = Mathf.Clamp(generations, 500, 1000);
+                float cross = Mathf.Clamp01(crossoverProb);
+                float mut = Mathf.Clamp(mutationProb, 0.10f, 0.20f);
+                _runner.RunGA(_chapas, pop, gens, cross, mut);
             }
 
             if (logToConsole)


### PR DESCRIPTION
## Summary
- Bias inspection genes with configurable probability
- Apply one-point crossover for inspection bits
- Clamp GA parameters, use tournament selection with stagnation termination, and preserve elites
- Validate Excel input with default inspection time and due date

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b87e8d2008832abc927558f2a08f71