### PR TITLE
Optimize Chapa GA for zero delays first

### DIFF
--- a/Assets/GA/ChapaFitness.cs
+++ b/Assets/GA/ChapaFitness.cs
@@ -40,7 +40,8 @@ namespace ChapasGA.GA
                 if (doInspect) inspections++;
                 if (C > chapa.DueDate) delays++;
             }
-            double fitness = (inspections * 1.0) - (delays * 100.0);
+            // Prioritize zero delays; only count inspections when no delays occur.
+            double fitness = delays == 0 ? inspections : -(delays * 1000.0);
             return (fitness, inspections, delays, completionTimes);
         }
     }


### PR DESCRIPTION
## Summary
- Prioritize solutions with no delays in Chapa GA fitness function to maximize inspections only when delays are zero

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b88d51c654832ab8541dad5982a6f7