### PR TITLE
Remove inspection repair from chromosomes

### DIFF
--- a/Assets/GA/ChapaChromosome.cs
+++ b/Assets/GA/ChapaChromosome.cs
@@ -7,21 +7,19 @@ namespace ChapasGA.GA
 {
     public class ChapaChromosome : ChromosomeBase
     {
-        private readonly int[] _mandatory;
         public int LengthPerPart { get; }
 
-        public ChapaChromosome(int length, int[] mandatory)
+        public ChapaChromosome(int length)
             : base(length * 2)
         {
             LengthPerPart = length;
-            _mandatory = mandatory;
             CreateGenes();
             Repair();
         }
 
         public override IChromosome CreateNew()
         {
-            return new ChapaChromosome(LengthPerPart, _mandatory);
+            return new ChapaChromosome(LengthPerPart);
         }
 
         public override Gene GenerateGene(int geneIndex)
@@ -31,8 +29,7 @@ namespace ChapasGA.GA
             {
                 return new Gene(rnd.GetInt(0, LengthPerPart));
             }
-            var idx = geneIndex - LengthPerPart;
-            return new Gene(_mandatory[idx] == 1 ? 1 : rnd.GetInt(0, 2));
+            return new Gene(rnd.GetInt(0, 2));
         }
 
         public int[] GetOrder()

--- a/Assets/GA/ChapaChromosome.cs
+++ b/Assets/GA/ChapaChromosome.cs
@@ -69,19 +69,6 @@ namespace ChapasGA.GA
             {
                 ReplaceGene(i, new Gene(fixedOrder[i]));
             }
-            // Repair bits
-            var bits = GetInspectionBits();
-            for (int i = 0; i < bits.Length; i++)
-            {
-                if (_mandatory[i] == 1)
-                {
-                    bits[i] = 1;
-                }
-            }
-            for (int i = 0; i < bits.Length; i++)
-            {
-                ReplaceGene(LengthPerPart + i, new Gene(bits[i]));
-            }
         }
     }
 }

--- a/Assets/GA/ChapaFitness.cs
+++ b/Assets/GA/ChapaFitness.cs
@@ -33,7 +33,7 @@ namespace ChapasGA.GA
             {
                 int idx = order[i];
                 var chapa = _chapas[idx];
-                bool doInspect = bits[idx] == 1 || chapa.inspeccionOn == 1;
+                bool doInspect = bits[idx] == 1;
                 double proc = chapa.tSoldadura + (doInspect ? chapa.tInspeccion : 0);
                 C += proc;
                 completionTimes[i] = C;

--- a/Assets/GA/ChapaGARunner.cs
+++ b/Assets/GA/ChapaGARunner.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using ChapasGA.Models;
 using GeneticSharp.Domain;
 using GeneticSharp.Domain.Populations;
@@ -20,8 +19,7 @@ namespace ChapasGA.GA
         public void RunGA(IList<Chapa> chapas, int populationSize, int generations, float crossoverProb, float mutationProb)
         {
             int n = chapas.Count;
-            var mandatory = chapas.Select(c => c.inspeccionOn).ToArray();
-            var chromosome = new ChapaChromosome(n, mandatory);
+            var chromosome = new ChapaChromosome(n);
             var fitness = new ChapaFitness(chapas);
             var population = new Population(populationSize, populationSize, chromosome);
             var selection = new TournamentSelection();

--- a/Assets/IO/CsvResultWriter.cs
+++ b/Assets/IO/CsvResultWriter.cs
@@ -16,7 +16,7 @@ namespace ChapasGA.IO
             {
                 int idx = order[i];
                 var c = chapas[idx];
-                bool doInspect = bits[idx] == 1 || c.inspeccionOn == 1;
+                bool doInspect = bits[idx] == 1;
                 double completion = completionTimes[i];
                 bool isLate = completion > c.DueDate;
                 sw.WriteLine($"{i};{c.Name};{(doInspect ? 1 : 0)};{completion};{c.DueDate};{(isLate ? 1 : 0)}");

--- a/Assets/Mono/ChapasGAController.cs
+++ b/Assets/Mono/ChapasGAController.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using ChapasGA.GA;
 using ChapasGA.IO;
 using ChapasGA.Models;
@@ -50,8 +49,7 @@ namespace ChapasGA.Mono
             if (dryRun)
             {
                 int n = _chapas.Count;
-                var mandatory = _chapas.Select(c => c.inspeccionOn).ToArray();
-                var chromo = new ChapaChromosome(n, mandatory);
+                var chromo = new ChapaChromosome(n);
                 for (int i = 0; i < n; i++)
                 {
                     chromo.ReplaceGene(i, new Gene(i));


### PR DESCRIPTION
## Summary
- Stop repairing inspection bits in `ChapaChromosome.Repair` so GA can alter inspection genes freely

## Testing
- `dotnet build` *(fails: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b897e34f90832aa74798838eb52a71